### PR TITLE
Remove `.json` extension from URL paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,7 @@ Rails.application.routes.draw do
   #resources :complexities, only: :show do
   #
   #end
-  get "/complexity-of-need/offender-no/:offender_no" => "complexities#show"
+  defaults format: :json do
+    get "/complexity-of-need/offender-no/:offender_no" => "complexities#show"
+  end
 end

--- a/spec/requests/complexities_request_spec.rb
+++ b/spec/requests/complexities_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Complexities", type: :request do
     }
 
     it "returns complexity" do
-      get "/complexity-of-need/offender-no/#{complexity.offender_no}.json"
+      get "/complexity-of-need/offender-no/#{complexity.offender_no}"
 
       expect(response).to have_http_status :ok
       expect(JSON.parse(response.body))
@@ -24,7 +24,7 @@ RSpec.describe "Complexities", type: :request do
 
   context "when not found" do
     it "returns 404" do
-      get "/complexity-of-need/offender-no/27.json"
+      get "/complexity-of-need/offender-no/27"
 
       expect(response).to have_http_status :not_found
     end
@@ -36,7 +36,7 @@ RSpec.describe "Complexities", type: :request do
     }
 
     it "returns complexity" do
-      get "/complexity-of-need/offender-no/#{complexity.offender_no}.json"
+      get "/complexity-of-need/offender-no/#{complexity.offender_no}"
 
       expect(response).to have_http_status :ok
       expect(JSON.parse(response.body))


### PR DESCRIPTION
According to the swagger definition, this API should only give JSON responses and does not require a `.json` extension to be added to requests to endpoints.

This commit removes the requirement for callers to specify `.json` by configuring the router to default to JSON format.

Now, every call to endpoint:
```
/complexity-of-need/offender-no/:offender_no
```

will respond with JSON, even if the `.json` extension isn't added.