### PR TITLE
MO-416 Part 1: Add write and multiple get endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,4 +29,4 @@ Style/FrozenStringLiteralComment:
   Enabled: true
 
 RSpec/ExampleLength:
-  Max: 10
+  Max: 11

--- a/app/controllers/complexities_controller.rb
+++ b/app/controllers/complexities_controller.rb
@@ -3,14 +3,30 @@
 class ComplexitiesController < ApplicationController
   respond_to :json
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :validation_error
 
   def show
     @complexity = Complexity.find_by!(offender_no: params[:offender_no])
   end
 
+  def create
+    @complexity = Complexity.create!(create_params)
+    render "show"
+  end
+
 private
 
   def not_found
-    render json: { error: "Not found" }.to_json, status: :not_found
+    render json: { message: "No record found for that offender" }, status: :not_found
+  end
+
+  def validation_error(error)
+    render json: { message: "Validation error", errors: error.record.errors }, status: :bad_request
+  end
+
+  def create_params
+    params.permit(:offender_no, :level, :sourceUser, :notes)
+          .transform_keys { |k| k == "sourceUser" ? "source_user" : k } # Convert "sourceUser" key to "source_user"
+          .merge(source_system: "hardcoded-oauth-client-id") # TODO: use the HMPPS oAuth client ID here
   end
 end

--- a/app/controllers/complexities_controller.rb
+++ b/app/controllers/complexities_controller.rb
@@ -14,6 +14,12 @@ class ComplexitiesController < ApplicationController
     render "show"
   end
 
+  def multiple
+    return missing_offender_numbers unless params["_json"].is_a? Array
+
+    @complexities = Complexity.latest_for_offenders(params["_json"])
+  end
+
 private
 
   def not_found
@@ -22,6 +28,10 @@ private
 
   def validation_error(error)
     render json: { message: "Validation error", errors: error.record.errors }, status: :bad_request
+  end
+
+  def missing_offender_numbers
+    render json: { message: "You must provide a JSON array of NOMIS Offender Numbers in the request body" }, status: :bad_request
   end
 
   def create_params

--- a/app/controllers/complexities_controller.rb
+++ b/app/controllers/complexities_controller.rb
@@ -6,7 +6,7 @@ class ComplexitiesController < ApplicationController
   rescue_from ActiveRecord::RecordInvalid, with: :validation_error
 
   def show
-    @complexity = Complexity.find_by!(offender_no: params[:offender_no])
+    @complexity = Complexity.order(created_at: :desc).find_by!(offender_no: params[:offender_no])
   end
 
   def create

--- a/app/models/complexity.rb
+++ b/app/models/complexity.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class Complexity < ApplicationRecord
+  VALID_LEVELS = %w[low medium high].freeze
+
+  validates :offender_no, presence: true
+  validates :level, inclusion: {
+    in: VALID_LEVELS, allow_nil: false,
+    message: "Must be low, medium or high"
+  }
 end

--- a/app/models/complexity.rb
+++ b/app/models/complexity.rb
@@ -8,4 +8,11 @@ class Complexity < ApplicationRecord
     in: VALID_LEVELS, allow_nil: false,
     message: "Must be low, medium or high"
   }
+
+  # Get the latest/current Complexity for the given offenders
+  def self.latest_for_offenders(offender_nos)
+    self.select("DISTINCT ON (offender_no) *")
+        .order(:offender_no, created_at: :desc)
+        .where(offender_no: offender_nos)
+  end
 end

--- a/app/views/complexities/_complexity.json.jbuilder
+++ b/app/views/complexities/_complexity.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.offenderNo complexity.offender_no
+json.extract! complexity, :level
+json.createdTimeStamp complexity.created_at
+json.sourceUser complexity.source_user if complexity.source_user
+json.sourceSystem complexity.source_system
+json.extract! complexity, :notes if complexity.notes

--- a/app/views/complexities/multiple.json.jbuilder
+++ b/app/views/complexities/multiple.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "complexity", collection: @complexities, as: :complexity

--- a/app/views/complexities/show.json.jbuilder
+++ b/app/views/complexities/show.json.jbuilder
@@ -1,8 +1,3 @@
 # frozen_string_literal: true
 
-json.offenderNo @complexity.offender_no
-json.extract! @complexity, :level
-json.createdTimeStamp @complexity.created_at
-json.sourceUser @complexity.source_user if @complexity.source_user
-json.sourceSystem @complexity.source_system
-json.extract! @complexity, :notes if @complexity.notes
+json.partial! "complexity", complexity: @complexity

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Rails.application.routes.draw do
   defaults format: :json do
     get "/complexity-of-need/offender-no/:offender_no" => "complexities#show"
     post "/complexity-of-need/offender-no/:offender_no" => "complexities#create"
+    post "/complexity-of-need/multiple/offender-no" => "complexities#multiple"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,6 @@ Rails.application.routes.draw do
 
   defaults format: :json do
     get "/complexity-of-need/offender-no/:offender_no" => "complexities#show"
+    post "/complexity-of-need/offender-no/:offender_no" => "complexities#create"
   end
 end

--- a/spec/api/rswag_spec.rb
+++ b/spec/api/rswag_spec.rb
@@ -14,7 +14,7 @@ describe "Complexity API" do
               description: "NOMIS Offender Number", example: "A0000AA"
 
     get "Retrieves the current complexity" do
-      produces "application/json"
+      tags "Single Offender"
 
       response "200", "Offender's current Complexity of Need level found" do
         before do
@@ -36,9 +36,8 @@ describe "Complexity API" do
     end
 
     post "Store a new Complexity of Need entry for the given NOMIS Offender Number" do
+      tags "Single Offender"
       description "Requires role: `CHANGE_COMPLEXITY`"
-      consumes "application/json"
-      produces "application/json"
 
       parameter name: :body, in: :body, schema: { "$ref" => "#/components/schemas/NewComplexityOfNeed" }
 
@@ -55,6 +54,39 @@ describe "Complexity API" do
         let(:offender_no) { "G4273GI" }
         let(:body) { { level: "potato" } }
 
+        run_test!
+      end
+    end
+  end
+
+  path "/complexity-of-need/multiple/offender-no" do
+    post "Retrieve Complexity of Need entries for the given set of NOMIS Offender Numbers" do
+      tags "Multiple Offenders"
+      description <<~DESC
+        This endpoint returns a JSON array containing the current Complexity of Need entry for multiple offenders.
+
+        The response array:
+          - will exclude offenders whose Complexity of Need level is not known (i.e. these would result in a `404 Not Found` error on the single `GET` endpoint)
+          - is not sorted in the same order as the request body
+          - is not paginated
+      DESC
+
+      parameter name: :body, in: :body, schema: {
+        type: :array,
+        items: { "$ref" => "#/components/schemas/OffenderNo" },
+        description: "A JSON array of NOMIS Offender Numbers",
+        example: %w[A0000AA B0000BB C0000CC],
+      }
+
+      response "200", "OK" do
+        schema type: :array, items: { "$ref" => "#/components/schemas/ComplexityOfNeed" }
+
+        let(:body) { %w[G4273GI A1111AA] }
+
+        run_test!
+      end
+
+      response "400", "The request body was invalid. Make sure you've provided a JSON array of NOMIS Offender Numbers." do
         run_test!
       end
     end

--- a/spec/api/rswag_spec.rb
+++ b/spec/api/rswag_spec.rb
@@ -10,11 +10,13 @@ require "swagger_helper"
 # Authorization 'method' needs to be defined for rswag
 describe "Complexity API" do
   path "/complexity-of-need/offender-no/{offender_no}" do
+    parameter name: :offender_no, in: :path, type: :string,
+              description: "NOMIS Offender Number", example: "A0000AA"
+
     get "Retrieves the current complexity" do
       produces "application/json"
-      parameter name: :offender_no, in: :path, type: :string, description: "NOMIS Offender Number"
 
-      response "200", "complexity found" do
+      response "200", "Offender's current Complexity of Need level found" do
         before do
           create(:complexity, :with_user, offender_no: offender_no)
         end
@@ -26,8 +28,32 @@ describe "Complexity API" do
         run_test!
       end
 
-      response "404", "record not found" do
+      response "404", "The Complexity of Need level for this offender is not known" do
         let(:offender_no) { "A1111AA" }
+
+        run_test!
+      end
+    end
+
+    post "Store a new Complexity of Need entry for the given NOMIS Offender Number" do
+      description "Requires role: `CHANGE_COMPLEXITY`"
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :body, in: :body, schema: { "$ref" => "#/components/schemas/NewComplexityOfNeed" }
+
+      response "200", "Complexity of Need level set successfully" do
+        schema "$ref" => "#/components/schemas/ComplexityOfNeed"
+
+        let(:offender_no) { "G4273GI" }
+        let(:body) { { level: "medium" } }
+
+        run_test!
+      end
+
+      response "400", "There were validation errors. Make sure you've given a valid level." do
+        let(:offender_no) { "G4273GI" }
+        let(:body) { { level: "potato" } }
 
         run_test!
       end

--- a/spec/factories/complexities.rb
+++ b/spec/factories/complexities.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     trait :with_user do
       source_user { "A_NOMIS_USER" }
     end
+
+    trait :with_notes do
+      notes { "Some reason why this level was given" }
+    end
   end
 end

--- a/spec/factories/complexities.rb
+++ b/spec/factories/complexities.rb
@@ -6,12 +6,20 @@ FactoryBot.define do
     level { Complexity::VALID_LEVELS.sample }
     source_system { "omic-mpc-something" }
 
+    # Complexity records are never edited, so updated_at should always equal created_at
+    updated_at { created_at }
+
     trait :with_user do
       source_user { "A_NOMIS_USER" }
     end
 
     trait :with_notes do
       notes { "Some reason why this level was given" }
+    end
+
+    # Set created_at to a random date in the past
+    trait :random_date do
+      created_at { Kernel.rand(1.year.ago..1.minute.ago) }
     end
   end
 end

--- a/spec/factories/complexities.rb
+++ b/spec/factories/complexities.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :complexity do
     offender_no { "1234567" }
-    level { "high" }
+    level { Complexity::VALID_LEVELS.sample }
     source_system { "omic-mpc-something" }
 
     trait :with_user do

--- a/spec/models/complexity_spec.rb
+++ b/spec/models/complexity_spec.rb
@@ -3,5 +3,35 @@
 require "rails_helper"
 
 RSpec.describe Complexity, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "VALID_LEVELS" do
+    it "is array: low, medium and high" do
+      expect(described_class::VALID_LEVELS).to eq(%w[low medium high])
+    end
+  end
+
+  describe "validation" do
+    describe "#level" do
+      it "can only be: low, medium or high" do
+        described_class::VALID_LEVELS.each do |level|
+          expect(build(:complexity, level: level)).to be_valid
+        end
+
+        %w[any other value].each do |bad_level|
+          expect(build(:complexity, level: bad_level)).not_to be_valid
+        end
+      end
+
+      it "cannot be blank" do
+        expect(build(:complexity, level: nil)).not_to be_valid
+        expect(build(:complexity, level: "")).not_to be_valid
+      end
+    end
+
+    describe "#offender_no" do
+      it "cannot be blank" do
+        expect(build(:complexity, offender_no: nil)).not_to be_valid
+        expect(build(:complexity, offender_no: "")).not_to be_valid
+      end
+    end
+  end
 end

--- a/spec/requests/complexities_request_spec.rb
+++ b/spec/requests/complexities_request_spec.rb
@@ -3,50 +3,156 @@
 require "rails_helper"
 
 RSpec.describe "Complexities", type: :request do
-  context "when default" do
-    let!(:complexity) {
-      create(:complexity)
-    }
+  describe "GET /complexity-of-need/offender-no/:offender_no" do
+    let(:offender_no) { complexity.offender_no }
 
-    it "returns complexity" do
-      get "/complexity-of-need/offender-no/#{complexity.offender_no}"
+    before do
+      get "/complexity-of-need/offender-no/#{offender_no}"
+    end
 
-      expect(response).to have_http_status :ok
-      expect(JSON.parse(response.body))
-          .to eq({
+    context "when default" do
+      let!(:complexity) {
+        create(:complexity)
+      }
+
+      it "returns complexity" do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body))
+          .to eq(JSON.parse({
                    offenderNo: complexity.offender_no,
                    level: complexity.level,
                    sourceSystem: complexity.source_system,
                    createdTimeStamp: JSON.parse(complexity.created_at.to_json),
-                 }.stringify_keys)
+                 }.to_json))
+      end
     end
-  end
 
-  context "when not found" do
-    it "returns 404" do
-      get "/complexity-of-need/offender-no/27"
+    context "with all fields populated" do
+      let!(:complexity) {
+        create(:complexity, :with_user, :with_notes)
+      }
 
-      expect(response).to have_http_status :not_found
-    end
-  end
-
-  context "with a source user" do
-    let!(:complexity) {
-      create(:complexity, :with_user)
-    }
-
-    it "returns complexity" do
-      get "/complexity-of-need/offender-no/#{complexity.offender_no}"
-
-      expect(response).to have_http_status :ok
-      expect(JSON.parse(response.body))
-          .to eq({
+      it "returns complexity" do
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body))
+          .to eq(JSON.parse({
                    sourceUser: complexity.source_user,
+                   notes: complexity.notes,
                    offenderNo: complexity.offender_no,
                    level: complexity.level,
                    sourceSystem: complexity.source_system,
                    createdTimeStamp: JSON.parse(complexity.created_at.to_json),
-                 }.stringify_keys)
+                 }.to_json))
+      end
+    end
+
+    context "when not found" do
+      let(:offender_no) { "non_existent_offender" }
+
+      it "returns 404" do
+        expect(response).to have_http_status :not_found
+      end
+
+      it "includes an error message" do
+        expect(JSON.parse(response.body))
+          .to eq(JSON.parse({
+                              message: "No record found for that offender",
+                            }.to_json))
+      end
+    end
+  end
+
+  describe "POST /complexity-of-need/offender-no/:offender_no" do
+    let(:offender_no) { "ABC123" }
+
+    before do
+      post "/complexity-of-need/offender-no/#{offender_no}", params: post_body, as: :json
+    end
+
+    context "with only mandatory fields" do
+      let(:post_body) {
+        {
+          level: "high",
+        }
+      }
+
+      it "creates a new record" do
+        expect(response).to have_http_status :ok
+        complexity = Complexity.find_by!(offender_no: offender_no)
+        expect(JSON.parse(response.body))
+          .to eq(JSON.parse({
+                   offenderNo: offender_no,
+                   level: post_body.fetch(:level),
+                   sourceSystem: "hardcoded-oauth-client-id",
+                   createdTimeStamp: complexity.created_at,
+                 }.to_json))
+      end
+    end
+
+    context "with optional fields included" do
+      let(:post_body) {
+        {
+          level: "high",
+          sourceUser: "SOME_NOMIS_USER",
+          notes: "Some free-text notes supplied by the user",
+        }
+      }
+
+      it "creates a new record" do
+        expect(response).to have_http_status :ok
+        complexity = Complexity.find_by!(offender_no: offender_no)
+        expect(JSON.parse(response.body))
+          .to eq(JSON.parse({
+                              sourceUser: post_body.fetch(:sourceUser),
+                              notes: post_body.fetch(:notes),
+                              offenderNo: offender_no,
+                              level: post_body.fetch(:level),
+                              sourceSystem: "hardcoded-oauth-client-id",
+                              createdTimeStamp: complexity.created_at,
+                            }.to_json))
+      end
+    end
+
+    context "with mandatory fields missing" do
+      let(:post_body) {
+        {
+          # "level" is missing
+          sourceUser: "SOME_NOMIS_USER",
+          notes: "Some free-text notes supplied by the user",
+        }
+      }
+
+      it "returns HTTP 400 Bad Request" do
+        expect(response).to have_http_status :bad_request
+      end
+
+      it "includes validation errors in the response" do
+        expect(JSON.parse(response.body))
+          .to eq(JSON.parse({
+                              message: "Validation error",
+                              errors: { level: ["Must be low, medium or high"] },
+                            }.to_json))
+      end
+    end
+
+    context "with an invalid complexity level" do
+      let(:post_body) {
+        {
+          level: "something invalid",
+        }
+      }
+
+      it "returns HTTP 400 Bad Request" do
+        expect(response).to have_http_status :bad_request
+      end
+
+      it "includes validation errors in the response" do
+        expect(JSON.parse(response.body))
+          .to eq(JSON.parse({
+                              message: "Validation error",
+                              errors: { level: ["Must be low, medium or high"] },
+                            }.to_json))
+      end
     end
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -21,6 +21,8 @@ RSpec.configure do |config|
         title: "API V1",
         version: "v1",
       },
+      consumes: ["application/json"],
+      produces: ["application/json"],
       components: {
         schemas: {
           Level: {
@@ -29,14 +31,15 @@ RSpec.configure do |config|
             description: "Complexity of Need Level",
             example: Complexity::VALID_LEVELS.first,
           },
+          OffenderNo: {
+            type: :string,
+            description: "NOMIS Offender Number",
+            example: "A0000AA",
+          },
           ComplexityOfNeed: {
             type: :object,
             properties: {
-              offenderNo: {
-                type: :string,
-                description: "NOMIS Offender Number",
-                example: "A0000AA",
-              },
+              offenderNo: { "$ref" => "#/components/schemas/OffenderNo" },
               level: { "$ref" => "#/components/schemas/Level" },
               sourceUser: {
                 type: :string,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -25,9 +25,9 @@ RSpec.configure do |config|
         schemas: {
           Level: {
             type: :string,
-            enum: %w[low medium high],
+            enum: Complexity::VALID_LEVELS,
             description: "Complexity of Need Level",
-            example: "medium",
+            example: Complexity::VALID_LEVELS.first,
           },
           ComplexityOfNeed: {
             type: :object,
@@ -40,12 +40,12 @@ RSpec.configure do |config|
               level: { "$ref" => "#/components/schemas/Level" },
               sourceUser: {
                 type: :string,
-                description: "The NOMIS user id who supplied this value via manual entry",
+                description: "The NOMIS username that supplied this Complexity of Need entry",
                 example: "JSMITH_GEN",
               },
               sourceSystem: {
                 type: :string,
-                description: "The client id of the system that created this entry",
+                description: "The OAuth Client ID of the system that created this entry",
                 example: "hmpps-api-client-id",
               },
               notes: {
@@ -55,11 +55,28 @@ RSpec.configure do |config|
               createdTimeStamp: {
                 type: :string,
                 format: :date_time,
-                description: "The date & time this entry was created",
-                example: "2021-03-02T12:20:47+00:00",
+                description: "The date & time this entry was created (in RFC 3339 format)",
+                example: "2021-03-02T17:18:46.457Z",
               },
             },
             required: %w[offenderNo level createdTimeStamp sourceSystem],
+            additionalProperties: false,
+          },
+          NewComplexityOfNeed: {
+            type: :object,
+            properties: {
+              level: { "$ref" => "#/components/schemas/Level" },
+              sourceUser: {
+                type: :string,
+                description: "The NOMIS username that supplied this Complexity of Need entry",
+                example: "JSMITH_GEN",
+              },
+              notes: {
+                type: :string,
+                description: "Free-text notes for this entry",
+              },
+            },
+            required: %w[level],
             additionalProperties: false,
           },
         },


### PR DESCRIPTION
Jira ticket: MO-416

---

This PR adds two endpoints to the API:

### `POST /complexity-of-need/offender-no/{offender_no}`

Use this endpoint to update the Complexity of Need level for the given offender.

**⚠️ Note: This endpoint is not currently authenticated**
This will be added in MO-538.

### `POST /complexity-of-need/multiple/offender-no`

Use this endpoint to retrieve the Complexity of Need levels of multiple offenders at once.

This has been implemented as a `POST` endpoint, where it should really be a `GET`, to allow clients to provide a list of offender numbers in the request body. This works around the query string length limitations of `GET` requests.

### Also changed

- Dry up JSON response parsing in the request spec (to remove the visual noise of repeated calls to `JSON.parse` and `.to_json`)
- Define `OffenderNo` as a schema in the Swagger document – since we use it in several places
- Configure the default request & response content types to always be `application/json` – so we don't need to repeatedly specify it in every endpoint
- Add a trait to the `Complexity` factory to randomise the creation date – useful for when multiple historic Complexity of Need levels are needed in tests