### PR TITLE
Add API versioning and server URLs to Swagger doc

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
+# For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
 
   get "/health" => "health#index"
 
+  # Default the request format to JSON – avoids need for .json file extension on paths
   defaults format: :json do
-    get "/complexity-of-need/offender-no/:offender_no" => "complexities#show"
-    post "/complexity-of-need/offender-no/:offender_no" => "complexities#create"
-    post "/complexity-of-need/multiple/offender-no" => "complexities#multiple"
+    # Prefix endpoints with /v1
+    scope path: "/v1" do
+      get "/complexity-of-need/offender-no/:offender_no" => "complexities#show"
+      post "/complexity-of-need/offender-no/:offender_no" => "complexities#create"
+      post "/complexity-of-need/multiple/offender-no" => "complexities#multiple"
+    end
   end
 end

--- a/spec/api/v1/rswag_spec.rb
+++ b/spec/api/v1/rswag_spec.rb
@@ -8,12 +8,12 @@ require "swagger_helper"
 # rubocop:disable RSpec/DescribeClass
 # rubocop:disable RSpec/EmptyExampleGroup
 # Authorization 'method' needs to be defined for rswag
-describe "Complexity API" do
+describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
   path "/complexity-of-need/offender-no/{offender_no}" do
     parameter name: :offender_no, in: :path, type: :string,
               description: "NOMIS Offender Number", example: "A0000AA"
 
-    get "Retrieves the current complexity" do
+    get "Retrieve the current Complexity of Need level for an offender" do
       tags "Single Offender"
 
       response "200", "Offender's current Complexity of Need level found" do
@@ -35,9 +35,9 @@ describe "Complexity API" do
       end
     end
 
-    post "Store a new Complexity of Need entry for the given NOMIS Offender Number" do
+    post "Update the Complexity of Need level for an offender" do
       tags "Single Offender"
-      description "Requires role: `CHANGE_COMPLEXITY`"
+      description "Clients calling this endpoint must have role: `ROLE_COMPLEXITY_OF_NEED` with scope: `write`"
 
       parameter name: :body, in: :body, schema: { "$ref" => "#/components/schemas/NewComplexityOfNeed" }
 
@@ -60,7 +60,7 @@ describe "Complexity API" do
   end
 
   path "/complexity-of-need/multiple/offender-no" do
-    post "Retrieve Complexity of Need entries for the given set of NOMIS Offender Numbers" do
+    post "Retrieve the current Complexity of Need levels for multiple offenders" do
       tags "Multiple Offenders"
       description <<~DESC
         This endpoint returns a JSON array containing the current Complexity of Need entry for multiple offenders.

--- a/spec/requests/v1/complexities_request_spec.rb
+++ b/spec/requests/v1/complexities_request_spec.rb
@@ -5,11 +5,12 @@ require "rails_helper"
 RSpec.describe "Complexities", type: :request do
   let(:response_json) { JSON.parse(response.body) }
 
-  describe "GET /complexity-of-need/offender-no/:offender_no" do
+  describe "GET /v1/complexity-of-need/offender-no/:offender_no" do
+    let(:endpoint) { "/v1/complexity-of-need/offender-no/#{offender_no}" }
     let(:offender_no) { complexity.offender_no }
 
     before do
-      get "/complexity-of-need/offender-no/#{offender_no}"
+      get endpoint
     end
 
     context "when default" do
@@ -68,7 +69,7 @@ RSpec.describe "Complexities", type: :request do
           create(:complexity, offender_no: different_offender_no, created_at: date, updated_at: date)
         end
 
-        get "/complexity-of-need/offender-no/#{offender_no}"
+        get endpoint
       end
 
       it "returns the most recent one for the specified offender" do
@@ -83,11 +84,12 @@ RSpec.describe "Complexities", type: :request do
     end
   end
 
-  describe "POST /complexity-of-need/offender-no/:offender_no" do
+  describe "POST /v1/complexity-of-need/offender-no/:offender_no" do
+    let(:endpoint) { "/v1/complexity-of-need/offender-no/#{offender_no}" }
     let(:offender_no) { "ABC123" }
 
     before do
-      post "/complexity-of-need/offender-no/#{offender_no}", params: post_body, as: :json
+      post endpoint, params: post_body, as: :json
     end
 
     context "with only mandatory fields" do
@@ -169,10 +171,12 @@ RSpec.describe "Complexities", type: :request do
     end
   end
 
-  describe "POST /complexity-of-need/multiple/offender-no" do
+  describe "POST /v1/complexity-of-need/multiple/offender-no" do
+    let(:endpoint) { "/v1/complexity-of-need/multiple/offender-no" }
+
     context "with a missing or invalid request body" do
       before do
-        post "/complexity-of-need/multiple/offender-no"
+        post endpoint
       end
 
       it "returns HTTP 400 Bad Request" do
@@ -187,10 +191,10 @@ RSpec.describe "Complexities", type: :request do
 
     context "with an empty array" do
       before do
-        post "/complexity-of-need/multiple/offender-no", params: [], as: :json
+        post endpoint, params: [], as: :json
       end
 
-      it "returns an empty array" do
+      it "returns an empty result set" do
         expect(response_json).to eq json_object([])
       end
     end
@@ -221,7 +225,7 @@ RSpec.describe "Complexities", type: :request do
         create_list(:complexity, 10, :random_date, offender_no: offender_with_multiple_levels)
         create(:complexity, :random_date, :with_user, :with_notes, offender_no: offender_with_one_level)
 
-        post "/complexity-of-need/multiple/offender-no", params: post_body, as: :json
+        post endpoint, params: post_body, as: :json
       end
 
       it "returns an array of the current Complexity level for each offender" do
@@ -257,7 +261,7 @@ RSpec.describe "Complexities", type: :request do
           create(:complexity, :random_date, offender_no: offender)
         }
 
-        post "/complexity-of-need/multiple/offender-no", params: offenders, as: :json
+        post endpoint, params: offenders, as: :json
       end
 
       it "returns all records without paginating" do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -16,10 +16,29 @@ RSpec.configure do |config|
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
     "v1/swagger.yaml" => {
+      basePath: "/v1",
       openapi: "3.0.1",
       info: {
-        title: "API V1",
+        title: "Complexity of Need API",
         version: "v1",
+        description: <<~DESC,
+          A microservice which holds the Complexity of Need level associated with offenders
+
+          ### Authentication
+
+          This API is secured by OAuth 2 with tokens supplied by HMPPS Auth.
+
+          Read permissions are granted to any authorised client. No particular role is required.
+
+          Write permissions are granted to clients with the role `ROLE_COMPLEXITY_OF_NEED` and a `write` scope.
+
+          ---
+
+          Owned by the **Manage POM Cases** team
+
+          - Slack: [#ask_moic_pvb](https://mojdt.slack.com/channels/ask_moic_pvb)
+          - GitHub: [ministryofjustice/hmpps-complexity-of-need](https://github.com/ministryofjustice/hmpps-complexity-of-need)
+        DESC
       },
       consumes: ["application/json"],
       produces: ["application/json"],
@@ -84,15 +103,29 @@ RSpec.configure do |config|
           },
         },
       },
+      tags: [
+        {
+          name: "Single Offender",
+          description: "Access Complexity of Need for a single offender",
+        },
+        {
+          name: "Multiple Offenders",
+          description: "Access Complexity of Need for multiple offenders at once",
+        },
+      ],
       paths: {},
       servers: [
         {
-          url: "https://{defaultHost}",
-          variables: {
-            defaultHost: {
-              default: "www.example.com",
-            },
-          },
+          url: "https://complexity-of-need-staging.hmpps.service.justice.gov.uk/v1",
+          description: "Staging/dev environment",
+        },
+        {
+          url: "https://complexity-of-need-preprod.hmpps.service.justice.gov.uk/v1",
+          description: "Pre-production environment",
+        },
+        {
+          url: "https://complexity-of-need.hmpps.service.justice.gov.uk/v1",
+          description: "Production environment",
         },
       ],
     },


### PR DESCRIPTION
This PR adds a `/v1` prefix to all endpoint paths.

Adding versioning to our API paths upfront gives us the ability to accommodate future breaking changes – i.e. by creating a `v2`, and so on

It also adds the expected hostnames for the API – although these aren't yet setup in the Cloud Platform.