### PR TITLE
Add hostname to staging environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,6 @@ workflows:
             branches:
               only:
                 - main
-                - mo418-add-hosting-infrastructure
       - deploy_staging:
           requires:
             - build_and_push_docker_image
@@ -216,4 +215,3 @@ workflows:
             branches:
               only:
                 - main
-                - mo418-add-hosting-infrastructure

--- a/deploy/staging/ingress.yaml
+++ b/deploy/staging/ingress.yaml
@@ -9,8 +9,18 @@ spec:
   tls:
   - hosts:
     - hmpps-complexity-of-need-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - complexity-of-need-staging.hmpps.service.justice.gov.uk
+    secretName: staging-cert
   rules:
   - host: hmpps-complexity-of-need-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: hmpps-complexity-of-need
+          servicePort: 3000
+  - host: complexity-of-need-staging.hmpps.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
This commit makes the staging environment available at:
https://complexity-of-need-staging.hmpps.service.justice.gov.uk

This follows the convention of other HMPPS API hostnames.