### PR TITLE
MO-538: Require role to change offender complexity levels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,12 +34,12 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "rspec-rails"
   gem "rswag-specs"
-
   gem "rubocop"
   gem "rubocop-govuk", "~> 2.0"
   gem "rubocop-performance"
   gem "rubocop-rails"
   gem "rubocop-rspec"
+  gem "timecop"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     thor (1.1.0)
+    timecop (0.9.4)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
@@ -261,6 +262,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   shoulda-matchers
+  timecop
   tzinfo-data
 
 BUNDLED WITH

--- a/app/controllers/complexities_controller.rb
+++ b/app/controllers/complexities_controller.rb
@@ -5,6 +5,10 @@ class ComplexitiesController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActiveRecord::RecordInvalid, with: :validation_error
 
+  # Require write permissions to create new records
+  skip_before_action :authorise_read!,  only: [:create]
+  before_action      :authorise_write!, only: [:create]
+
   def show
     @complexity = Complexity.order(created_at: :desc).find_by!(offender_no: params[:offender_no])
   end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HealthController < ApplicationController
-  skip_before_action :authenticate!
+  skip_before_action :authorise_read!
 
   def index
     render plain: "Everything is fine."

--- a/app/services/hmpps_api/oauth/token.rb
+++ b/app/services/hmpps_api/oauth/token.rb
@@ -13,6 +13,7 @@ module HmppsApi
                              algorithms: "RS256",
                              iss: "#{Rails.configuration.nomis_oauth_host}/auth/issuer",
                              verify_iss: true,
+                             verify_expiration: true, # Raises error JWT::ExpiredSignature if the token has expired
                              verify_aud: false) do |header|
           jwks_hash[header["kid"]]
         end
@@ -22,12 +23,12 @@ module HmppsApi
         @access_token = access_token
       end
 
-      def expired?
-        @payload.fetch("exp") < Time.zone.now.to_i
+      def has_role?(role)
+        @payload.fetch("authorities", []).include?(role)
       end
 
-      def valid_token_with_scope?(scope)
-        @payload.fetch("scope", []).include?(scope) && !expired?
+      def has_scope?(scope)
+        @payload.fetch("scope", []).include?(scope)
       end
 
       def self.from_json(payload)

--- a/spec/auth_helper.rb
+++ b/spec/auth_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module AuthHelper
+  # Return a valid Authorization HTTP header with a real access token
+  # This allows us to test the HMPPS Auth integration
   def auth_header
     oauth_client = HmppsApi::Oauth::Client.new(Rails.configuration.nomis_oauth_host)
     route = "/auth/oauth/token?grant_type=client_credentials"
@@ -9,5 +11,13 @@ module AuthHelper
     token = HmppsApi::Oauth::Token.from_json(response)
 
     "Bearer #{token.access_token}"
+  end
+
+  # Mock the client's access token with the specified scopes and roles
+  def stub_access_token(scopes: [], roles: [])
+    token = instance_double(HmppsApi::Oauth::Token, access_token: "dummy-access-token")
+    allow(token).to receive(:has_scope?) { |scope| scopes.include?(scope) }
+    allow(token).to receive(:has_role?) { |role| roles.include?(role) }
+    allow(HmppsApi::Oauth::Token).to receive(:new).and_return(token)
   end
 end

--- a/spec/auth_helper.rb
+++ b/spec/auth_helper.rb
@@ -7,10 +7,8 @@ module AuthHelper
     oauth_client = HmppsApi::Oauth::Client.new(Rails.configuration.nomis_oauth_host)
     route = "/auth/oauth/token?grant_type=client_credentials"
     response = oauth_client.post(route)
-
-    token = HmppsApi::Oauth::Token.from_json(response)
-
-    "Bearer #{token.access_token}"
+    access_token = response.fetch("access_token")
+    "Bearer #{access_token}"
   end
 
   # Mock the client's access token with the specified scopes and roles


### PR DESCRIPTION
Jira ticket: MO-538

---

This pull request adds authorisation to the POST endpoint which updates the offender's Complexity of Need level.

The endpoint now requires the client to have role `ROLE_COMPLEXITY_OF_NEED` with scope `write`, as documented in the Swagger definition.

### Summary of changes

- Refactor the auth handling code in `ApplicationController` to make it reusable between `read` and `write` endpoints (use `authorise_read!` or `authorise_write!`)
- Remove redundant check for expired tokens in `HmppsApi::Oauth::Token` – `JWT.decode` already does this for us, and will raise an error if the token has expired
- Add `401 Unauthorized` and `403 Forbidden` response definitions to Swagger