### PR TITLE
Use mimemagic 0.3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,14 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore config files needed for local development
 /.idea
 *.iml
 .ruby-gemset
 .env
+Brewfile.lock.json
 
 # Ignore generated swagger definition
 # This is created dynamically by running: rake rswag
 /swagger
-.env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
     - 'spec/rails_helper.rb'
     - 'bin/*'
     - 'config/environments/*.rb'
+    - 'Brewfile'
 
 RSpec/NamedSubject:
   Enabled: false

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,13 @@
+# Brewfile: a Gemfile, but for Homebrew
+#
+# Install the dependencies in this file by running:
+# brew bundle
+#
+# Read more about Brewfiles here:
+# https://thoughtbot.com/blog/brewfile-a-gemfile-but-for-homebrew
+
+# required by Rails Active Record
+brew 'postgres'
+
+# required by gem 'mimemagic' v0.3.9
+brew 'shared-mime-info'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
This version of the gem is licenced under MIT, so it's fine for us to continue using.

It depends on a locally installed MIME database rather than it coming bundled with the gem.

This seems to be the approach that other development teams in MOJ are using, so I'm following their lead. See Slack thread here: https://mojdt.slack.com/archives/C7KCVJZSQ/p1616750434063200

### Local development

On local development machines, this means we'll need to install the homebrew package `shared-mime-info`. I've updated the `Brewfile` to include this as a project dependency – so developers will need to run `brew bundle` in their terminal to install it.

### Docker builds

`shared-mime-info` is already included in the `ruby:2.6.5-stretch` image which we build upon, so it's already accessible to the gem. No further action is required for this to work.