### PR TITLE
MO-553: Store the client ID as the source system

### DIFF
--- a/app/controllers/complexities_controller.rb
+++ b/app/controllers/complexities_controller.rb
@@ -46,6 +46,6 @@ private
   def create_params
     params.permit(:offender_no, :level, :sourceUser, :notes)
           .transform_keys { |k| k == "sourceUser" ? "source_user" : k } # Convert "sourceUser" key to "source_user"
-          .merge(source_system: "hardcoded-oauth-client-id") # TODO: use the HMPPS oAuth client ID here
+          .merge(source_system: token.client_id)
   end
 end

--- a/app/services/hmpps_api/oauth/token.rb
+++ b/app/services/hmpps_api/oauth/token.rb
@@ -23,6 +23,10 @@ module HmppsApi
         @access_token = access_token
       end
 
+      def client_id
+        @payload.fetch("client_id")
+      end
+
       def has_role?(role)
         @payload.fetch("authorities", []).include?(role)
       end

--- a/spec/requests/v1/complexities_request_spec.rb
+++ b/spec/requests/v1/complexities_request_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe "Complexities", type: :request do
   describe "POST /v1/complexity-of-need/offender-no/:offender_no" do
     let(:endpoint) { "/v1/complexity-of-need/offender-no/#{offender_no}" }
     let(:offender_no) { "ABC123" }
+    let(:source_system) { Rails.configuration.nomis_oauth_client_id }
 
     context "with only mandatory fields" do
       let(:post_body) {
@@ -158,7 +159,7 @@ RSpec.describe "Complexities", type: :request do
         expect(response_json)
           .to eq json_object(offenderNo: offender_no,
                              level: post_body.fetch(:level),
-                             sourceSystem: "hardcoded-oauth-client-id",
+                             sourceSystem: source_system,
                              createdTimeStamp: complexity.created_at)
       end
     end
@@ -184,7 +185,7 @@ RSpec.describe "Complexities", type: :request do
                              notes: post_body.fetch(:notes),
                              offenderNo: offender_no,
                              level: post_body.fetch(:level),
-                             sourceSystem: "hardcoded-oauth-client-id",
+                             sourceSystem: source_system,
                              createdTimeStamp: complexity.created_at)
       end
     end


### PR DESCRIPTION
New records written via the POST endpoint will include the caller's oAuth client ID as the 'source system'.