### PR TITLE
MO-541 Microservice | Implement health checks

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -4,6 +4,6 @@ class HealthController < ApplicationController
   skip_before_action :authorise_read!
 
   def index
-    render plain: "Everything is fine."
+    render plain: "pong"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   mount Rswag::Api::Engine => "/api-docs"
 
   get "/ping" => "health#index"
+  get "/health" => "health#index"
   get "/release" => "health#release"
 
   # Default the request format to JSON – avoids need for .json file extension on paths

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
 
-  get "/health" => "health#index"
+  get "/ping" => "health#index"
   get "/release" => "health#release"
 
   # Default the request format to JSON – avoids need for .json file extension on paths

--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -32,13 +32,13 @@ spec:
             - containerPort: 3000
           livenessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -32,13 +32,13 @@ spec:
             - containerPort: 3000
           livenessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -32,13 +32,13 @@ spec:
             - containerPort: 3000
           livenessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Health", type: :request do
-  describe "GET /health" do
-    it "says that eveything is ok" do
-      get "/health"
+  describe "GET /ping" do
+    it "says ping" do
+      get "/ping"
       expect(response).to have_http_status(200)
-      expect(response.body).to eq("Everything is fine.")
+      expect(response.body).to eq("pong")
     end
   end
 end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -4,10 +4,19 @@ require "rails_helper"
 
 RSpec.describe "Health", type: :request do
   describe "GET /ping" do
-    it "says ping" do
+    it "says pong" do
       get "/ping"
       expect(response).to have_http_status(200)
       expect(response.body).to eq("pong")
+    end
+  end
+
+  # This is just temporary while the DPS team move over to the new health check
+  # They currently only care about the status being 200
+  describe "GET /health" do
+    it "gets a status 200" do
+      get "/health"
+      expect(response).to have_http_status(200)
     end
   end
 end


### PR DESCRIPTION
This PR makes sure the health checks are consistent with other HMPPS APIs and have the same health check endpoint.
It creates endpoint GET /ping which always returns a plain text response of "pong" and it remove the GET /health endpoint as it’s no longer used by anything

It also changes those references to /health to /ping inside the deployment yaml files

This has now put back /health as an endpoint while DPS transition to the new health check endpoint. They only care about the 200 success. 