### PR TITLE
Make CircleCI wait until a deployment has been successful

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,16 @@ references:
         sudo apt-get --assume-yes install python3-pip
         sudo pip3 install awscli
 
+  install_yq: &install_yq
+    run:
+      name: Install yq (YAML parser)
+      command: |
+        wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -O - |\
+        tar xz && mv ${BINARY} /usr/bin/yq
+      environment:
+        VERSION: v4.6.3
+        BINARY: yq_linux_amd64
+
   build_docker_image: &build_docker_image
     run:
       name: Build docker image
@@ -195,7 +205,8 @@ jobs:
       - *install_gpg
       - *configure_gpg
       - *decrypt_secrets
-      - deploy:
+      - *install_yq
+      - run:
           name: Deploy to staging
           command: |
             kubectl delete job hmpps-complexity-of-need-migration --ignore-not-found
@@ -205,6 +216,9 @@ jobs:
             kubectl apply --record=false -f ./deploy/staging
           environment:
             <<: *github_team_name_slug
+      - run:
+          name: Wait for Kube to spin up new pods
+          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_STAGING_NAMESPACE" "hmpps-complexity-of-need" "$CIRCLE_SHA1"
 
   deploy_preprod:
     <<: *deploy_container_config
@@ -218,7 +232,8 @@ jobs:
       - *install_gpg
       - *configure_gpg
       - *decrypt_secrets
-      - deploy:
+      - *install_yq
+      - run:
           name: Deploy to pre-production
           command: |
             kubectl delete job rails-db-migration --ignore-not-found
@@ -228,6 +243,9 @@ jobs:
             kubectl apply --record=false -f ./deploy/preprod
           environment:
             <<: *github_team_name_slug
+      - run:
+          name: Wait for Kube to spin up new pods
+          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PREPROD_NAMESPACE" "hmpps-complexity-of-need" "$CIRCLE_SHA1"
 
   deploy_production:
     <<: *deploy_container_config
@@ -241,7 +259,8 @@ jobs:
       - *install_gpg
       - *configure_gpg
       - *decrypt_secrets
-      - deploy:
+      - *install_yq
+      - run:
           name: Deploy to production
           command: |
             kubectl delete job rails-db-migration --ignore-not-found
@@ -251,6 +270,9 @@ jobs:
             kubectl apply --record=false -f ./deploy/production
           environment:
             <<: *github_team_name_slug
+      - run:
+          name: Wait for Kube to spin up new pods
+          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PRODUCTION_NAMESPACE" "hmpps-complexity-of-need" "$CIRCLE_SHA1"
 
 workflows:
   build_and_test:

--- a/.circleci/wait-for-successful-deployment.sh
+++ b/.circleci/wait-for-successful-deployment.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Wait until the desired docker image is running in the target namespace and
+# all pods running other (old) images have been stopped
+#
+# Use in the CircleCI pipeline to check that a deployment has completed successfully
+#
+# Usage:
+#   bash wait-for-successful-deployment.sh "<kube namespace>" "<app name>" "<docker image tag>"
+#
+# Exit status code:
+#   0 (success) when all pods are running the image
+#   1 (failure) if gave up waiting for all pods to run the image
+
+# Configure bash to exit with an error code if any command in this script fails
+# Read more: https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euo pipefail
+
+NAMESPACE="$1"
+APP_NAME="$2"
+IMAGE_TAG="$3"
+
+# Wait for approx 5 minutes before giving up
+MAX_ATTEMPTS=30 # Number of checks to perform before giving up
+SLEEP_SECONDS=10 # Number of seconds to wait between each check
+
+i=1
+while [ $i -le $MAX_ATTEMPTS ]
+do
+  echo "Attempt $i of $MAX_ATTEMPTS"
+
+  # Find pods with status 'Running'
+  RUNNING_PODS=$(kubectl -n $NAMESPACE get pods --selector=app=$APP_NAME --field-selector=status.phase=Running --output yaml)
+
+  # Count the total number of pods running
+  RUNNING_POD_COUNT=$(echo "$RUNNING_PODS" | yq eval ".items | length" -)
+
+  # Extract a list of docker images running on those pods
+  RUNNING_POD_IMAGES=$(echo "$RUNNING_PODS" | yq eval ".items.[].spec.containers.[].image" -)
+
+  # Count the number of pods running the desired docker image
+  # Note: `grep -c` gives a non-zero exit code if 0 matches are found, so `|| true` is used to avoid that behaviour
+  RUNNING_DESIRED_IMAGE_COUNT=$(echo "$RUNNING_POD_IMAGES" | grep -c ":$IMAGE_TAG" || true)
+
+  if [ "$RUNNING_DESIRED_IMAGE_COUNT" -eq 0 ]; then
+    echo "No pods are running the desired image"
+  elif [ "$RUNNING_DESIRED_IMAGE_COUNT" -lt "$RUNNING_POD_COUNT" ]; then
+    # Not all pods are running the new image yet
+    echo "$RUNNING_DESIRED_IMAGE_COUNT out of $RUNNING_POD_COUNT pods are running the desired image"
+  else
+    # All pods are now running the new image
+    echo "All $RUNNING_POD_COUNT pods are now running the desired image"
+    # End the script with a 'success' exit code
+    exit 0
+  fi
+
+  echo # line break to separate attempts
+  sleep $SLEEP_SECONDS
+  i=$[$i+1]
+done
+
+echo "Giving up - something must have gone wrong with the deployment"
+echo # line break
+echo "This is the current state of pods running in $NAMESPACE:"
+kubectl -n $NAMESPACE get pods
+
+# End the script with a 'failure' exit code
+exit 1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
 
   get "/ping" => "health#index"
   get "/health" => "health#index"
-  get "/release" => "health#release"
 
   # Default the request format to JSON – avoids need for .json file extension on paths
   defaults format: :json do


### PR DESCRIPTION
This commit adds a check to the 'deploy' steps of our CircleCI pipeline. It'll query the Kubernetes cluster and wait until all running pods have switched over to the newly built/deployed docker image.

In CircleCI, this will be shown as the final step in the workflow job `deploy_<env>`.

## How it works

The script `.circleci/wait-for-successful-deployment.sh` polls the Kubernetes cluster to see which pods are running, and which docker image they're running.

The script will poll the cluster 30 times, approximately once every 10 seconds. This means it'll wait roughly 5 minutes for the new deployment to come online before giving up and considering it 'failed'. If failed, it'll output the current state of the pods for debugging purposes, and exit with a non-zero exit code causing the CircleCI job to fail.

✅ A deployment is considered successful once all pods are running the new image.

❌ A deployment is considered failed if old pods remain running, or the new ones don't start at all. At this point, manual intervention is required because it probably means the new pods are in a crash loop.

## Example

For example, when deploying to staging, the `deploy_staging` workflow step will look like this:

<img width="1210" alt="Screenshot 2021-04-01 at 16 30 59" src="https://user-images.githubusercontent.com/7735945/113318026-ec184600-9307-11eb-9eb4-6098aaa1ee12.png">

We use the ['rolling update'](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/) deployment strategy. This is reflected in the screenshot, which shows that 2 out of 4 pods were running the new image. Eventually there are only 2 pods running – both of which are on the new image – because the 2 old pods have been terminated.
