### PR TITLE
Configure IP allow list on preprod and production

### DIFF
--- a/deploy/preprod/ingress.yaml
+++ b/deploy/preprod/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: app-ingress
+  annotations:
+    # Only allow incoming traffic from other apps running in the MOJ Cloud Platform
+    nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32"
 spec:
   tls:
   - hosts:

--- a/deploy/production/ingress.yaml
+++ b/deploy/production/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: app-ingress
+  annotations:
+    # Only allow incoming traffic from other apps running in the MOJ Cloud Platform
+    nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
This commit adds an IP allow list to block traffic from unknown sources.

The only clients of the HMPPS Complexity of Need API are services which also run within the MOJ Cloud Platform. Therefore, the IP allow list only allows traffic which originates from the Cloud Platform.

This is possible by allowing only incoming traffic from the Cloud Platform's outgoing NAT gateways. The platform uses 'hairpin' routing, which means that traffic from other applications will travel 'out' of the platform via outgoing NAT gateway, and then back 'in' to this app.