### PR TITLE
refs MO-960 migrate application to live cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,11 @@ references:
   deploy_container_config: &deploy_container_config
     resource_class: small
     docker:
-      - image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools
         environment:
           KUBE_ENV_STAGING_NAMESPACE: hmpps-complexity-of-need-staging
-          KUBE_ENV_STAGING_NAME: live-1.cloud-platform.service.justice.gov.uk
           KUBE_ENV_PREPROD_NAMESPACE: hmpps-complexity-of-need-preprod
-          KUBE_ENV_PREPROD_NAME: live-1.cloud-platform.service.justice.gov.uk
           KUBE_ENV_PRODUCTION_NAMESPACE: hmpps-complexity-of-need-production
-          KUBE_ENV_PRODUCTION_NAME: live-1.cloud-platform.service.justice.gov.uk
 
   test_container_config: &test_container_config
     resource_class: small
@@ -198,10 +195,15 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Kubectl deployment staging setup
+          name: Kubectl deployment to live cluster staging setup
           command: |
-            setup-kube-auth
-            kubectl config use-context staging
+            echo -n ${CLUSTER_LIVE_CERT} | base64 -d > ./live_ca.crt
+            kubectl config set-cluster ${CLUSTER_NAME_LIVE} --certificate-authority=./live_ca.crt --server=https://${CLUSTER_NAME_LIVE}
+            kubectl config set-credentials circleci --token=${LIVE_STAGING_TOKEN}
+            kubectl config set-context ${CLUSTER_NAME_LIVE} --cluster=${CLUSTER_NAME_LIVE} --user=circleci --namespace=${KUBE_ENV_STAGING_NAMESPACE}
+            kubectl config use-context ${CLUSTER_NAME_LIVE}
+            kubectl config current-context
+            kubectl --namespace=${KUBE_ENV_STAGING_NAMESPACE} get pods
       - *install_gpg
       - *configure_gpg
       - *decrypt_secrets
@@ -214,6 +216,8 @@ jobs:
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/staging/migration-job.yaml
             kubectl annotate deployments/hmpps-complexity-of-need kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
             kubectl apply --record=false -f ./deploy/staging
+            kubectl apply --record=false -f ./deploy/staging/ingress/ingress.yaml
+            kubectl annotate deployments/hmpps-complexity-of-need kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
       - run:
@@ -227,8 +231,13 @@ jobs:
       - run:
           name: Kubectl deployment preproduction setup
           command: |
-            setup-kube-auth
-            kubectl config use-context preprod
+            echo -n ${CLUSTER_LIVE_CERT} | base64 -d > ./live_ca.crt
+            kubectl config set-cluster ${CLUSTER_NAME_LIVE} --certificate-authority=./live_ca.crt --server=https://${CLUSTER_NAME_LIVE}
+            kubectl config set-credentials circleci --token=${LIVE_PREPROD_TOKEN}
+            kubectl config set-context ${CLUSTER_NAME_LIVE} --cluster=${CLUSTER_NAME_LIVE} --user=circleci --namespace=${KUBE_ENV_PREPROD_NAMESPACE}
+            kubectl config use-context ${CLUSTER_NAME_LIVE}
+            kubectl config current-context
+            kubectl --namespace=${KUBE_ENV_PREPROD_NAMESPACE} get pods
       - *install_gpg
       - *configure_gpg
       - *decrypt_secrets
@@ -239,8 +248,9 @@ jobs:
             kubectl delete job rails-db-migration --ignore-not-found
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/preprod/deployment.yaml
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/preprod/migration-job.yaml
-            kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
             kubectl apply --record=false -f ./deploy/preprod
+            kubectl apply --record=false -f ./deploy/preprod/ingress/ingress.yaml
+            kubectl annotate deployments/hmpps-complexity-of-need kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
       - run:
@@ -254,8 +264,13 @@ jobs:
       - run:
           name: Kubectl deployment production setup
           command: |
-            setup-kube-auth
-            kubectl config use-context production
+            echo -n ${CLUSTER_LIVE_CERT} | base64 -d > ./live_ca.crt
+            kubectl config set-cluster ${CLUSTER_NAME_LIVE} --certificate-authority=./live_ca.crt --server=https://${CLUSTER_NAME_LIVE}
+            kubectl config set-credentials circleci --token=${LIVE_PRODUCTION_TOKEN}
+            kubectl config set-context ${CLUSTER_NAME_LIVE} --cluster=${CLUSTER_NAME_LIVE} --user=circleci --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE}
+            kubectl config use-context ${CLUSTER_NAME_LIVE}
+            kubectl config current-context
+            kubectl --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} get pods
       - *install_gpg
       - *configure_gpg
       - *decrypt_secrets
@@ -266,8 +281,9 @@ jobs:
             kubectl delete job rails-db-migration --ignore-not-found
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/production/deployment.yaml
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/production/migration-job.yaml
-            kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
             kubectl apply --record=false -f ./deploy/production
+            kubectl apply --record=false -f ./deploy/production/ingress/ingress.yaml
+            kubectl annotate deployments/hmpps-complexity-of-need kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
       - run:

--- a/deploy/preprod/ingress/ingress-live-1.yaml
+++ b/deploy/preprod/ingress/ingress-live-1.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: hmpps-complexity-of-need-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    # Only allow incoming traffic from: other apps running in the MOJ Cloud Platform, and the MOJ Digital VPN
+    nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,81.134.202.29/32"
+spec:
+  tls:
+  - hosts:
+    - hmpps-complexity-of-need-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - complexity-of-need-preprod.hmpps.service.justice.gov.uk
+    secretName: preprod-cert
+  rules:
+  - host: hmpps-complexity-of-need-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: app-service
+          servicePort: 3000
+  - host: complexity-of-need-preprod.hmpps.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: app-service
+          servicePort: 3000

--- a/deploy/preprod/ingress/ingress.yaml
+++ b/deploy/preprod/ingress/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: app-ingress
   annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: hmpps-complexity-of-need-staging-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
     # Only allow incoming traffic from: other apps running in the MOJ Cloud Platform, and the MOJ Digital VPN
     nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,81.134.202.29/32"
 spec:

--- a/deploy/preprod/migration-job.yaml
+++ b/deploy/preprod/migration-job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: hmpps-complexity-of-need-migration
 spec:
+  ttlSecondsAfterFinished: 3600
   completions: 1
   parallelism: 1
   template:

--- a/deploy/production/ingress/ingress-live-1.yaml
+++ b/deploy/production/ingress/ingress-live-1.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: hmpps-complexity-of-need-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    # Only allow incoming traffic from: other apps running in the MOJ Cloud Platform, and the MOJ Digital VPN
+    nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,81.134.202.29/32"
+spec:
+  tls:
+  - hosts:
+    - hmpps-complexity-of-need-production.apps.live-1.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - complexity-of-need.hmpps.service.justice.gov.uk
+    secretName: production-cert
+  rules:
+  - host: hmpps-complexity-of-need-production.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: app-service
+          servicePort: 3000
+  - host: complexity-of-need.hmpps.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: app-service
+          servicePort: 3000

--- a/deploy/production/ingress/ingress.yaml
+++ b/deploy/production/ingress/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: app-ingress
   annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: hmpps-complexity-of-need-staging-green
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
     # Only allow incoming traffic from: other apps running in the MOJ Cloud Platform, and the MOJ Digital VPN
     nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,81.134.202.29/32"
 spec:

--- a/deploy/production/migration-job.yaml
+++ b/deploy/production/migration-job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: hmpps-complexity-of-need-migration
 spec:
+  ttlSecondsAfterFinished: 3600
   completions: 1
   parallelism: 1
   template:

--- a/deploy/staging/ingress/ingress-live-1.yaml
+++ b/deploy/staging/ingress/ingress-live-1.yaml
@@ -4,6 +4,8 @@ metadata:
   name: hmpps-complexity-of-need
   namespace: hmpps-complexity-of-need-staging
   annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: hmpps-complexity-of-need-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
     kubernetes.io/ingress.class: "nginx"
 spec:
   tls:

--- a/deploy/staging/ingress/ingress.yaml
+++ b/deploy/staging/ingress/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: hmpps-complexity-of-need
+  namespace: hmpps-complexity-of-need-staging
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: hmpps-complexity-of-need-staging-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - hosts:
+    - hmpps-complexity-of-need-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - complexity-of-need-staging.hmpps.service.justice.gov.uk
+    secretName: staging-cert
+  rules:
+  - host: hmpps-complexity-of-need-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: hmpps-complexity-of-need
+          servicePort: 3000
+  - host: complexity-of-need-staging.hmpps.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: hmpps-complexity-of-need
+          servicePort: 3000

--- a/deploy/staging/migration-job.yaml
+++ b/deploy/staging/migration-job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: hmpps-complexity-of-need-migration
 spec:
+  ttlSecondsAfterFinished: 3600
   completions: 1
   parallelism: 1
   template:


### PR DESCRIPTION
Amend migration-job.yaml to use TTL setting. This allows the completed job to be deleted once complete. Keep ingress files for live-1 until the old cluster is deleted.