### PR TITLE
Remove support for hardcoded AWS access keys, rely on IRSA instead

### DIFF
--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -75,16 +75,6 @@ spec:
                 secretKeyRef:
                   name: rds-instance-output
                   key: database_username
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: secret_access_key
             - name: DOMAIN_EVENTS_TOPIC_ARN
               valueFrom:
                 secretKeyRef:

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -75,16 +75,6 @@ spec:
                 secretKeyRef:
                   name: rds-instance-output
                   key: database_username
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: secret_access_key
             - name: DOMAIN_EVENTS_TOPIC_ARN
               valueFrom:
                 secretKeyRef:

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -75,16 +75,6 @@ spec:
                 secretKeyRef:
                   name: hmpps-complexity-of-need-rds-instance-output
                   key: postgres_user
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: secret_access_key
             - name: DOMAIN_EVENTS_TOPIC_ARN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
WARNING only deploy this when relevant cloud-platform changes are made