### PR TITLE
Update bundler and CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,26 @@ jobs:
           name: Rubocop
           command: bundle exec rubocop
 
+  run_tests:
+    <<: *defaults
+    <<: *test_container_config
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run:
+          name: Security analysis
+          command: bundle exec brakeman -o ~/test-results/brakeman/brakeman.json -o ~/test-results/brakeman/brakeman.html
+      - run:
+          name: Check code coverage
+          command: bundle exec undercover --compare origin/main
+      - run:
+          name: Run RSpec tests
+          command: bundle exec rspec --format progress --format RspecJunitFormatter --out ~/rspec/rspec.xml
+      - store_test_results:
+          path: ~/rspec
+      - store_artifacts:
+          path: coverage
+
   build_and_push_docker_image:
     <<: *defaults
     <<: *test_container_config
@@ -246,9 +266,13 @@ workflows:
       - rubocop:
           requires:
             - install_dependencies
+      - run_tests:
+          requires:
+            - install_dependencies
       - build_and_push_docker_image:
           requires:
             - rubocop
+            - run_tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,16 @@ jobs:
       - run:
           name: Security analysis
           command: bundle exec brakeman -o ~/test-results/brakeman/brakeman.json -o ~/test-results/brakeman/brakeman.html
-      - run:
-          name: Check code coverage
-          command: bundle exec undercover --compare origin/main
-      - run:
-          name: Run RSpec tests
-          command: bundle exec rspec --format progress --format RspecJunitFormatter --out ~/rspec/rspec.xml
-      - store_test_results:
-          path: ~/rspec
-      - store_artifacts:
-          path: coverage
+#      - run:
+#          name: Run RSpec tests
+#          command: bundle exec rspec --format progress --format RspecJunitFormatter --out ~/rspec/rspec.xml
+#      - store_test_results:
+#          path: ~/rspec
+#      - store_artifacts:
+#          path: coverage
+#      - run:
+#         name: Check code coverage
+#         command: bundle exec undercover --compare origin/main
 
   build_and_push_docker_image:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,38 +108,24 @@ references:
         <<: *github_team_name_slug
 
 version: 2.1
+
+orbs:
+  ruby: circleci/ruby@2.1.3
+
 jobs:
   install_dependencies:
     <<: *defaults
     <<: *test_container_config
     steps:
-      - run:
-          name: Install CMake (required by Undercover gem)
-          command: sudo apt update && sudo apt install cmake
       - checkout
-      - restore_cache:
-          keys:
-            - hmpps-complexity-of-need-{{ checksum "Gemfile.lock" }}
-            - hmpps-complexity-of-need-
-      - run:
-          name: Which bundler?
-          command: bundle -v
-      - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
-      - save_cache:
-          key: hmpps-complexity-of-need-{{ checksum "Gemfile.lock" }}
-          paths:
-            - ~/repo/vendor/bundle
+      - ruby/install-deps
 
   rubocop:
     <<: *defaults
     <<: *test_container_config
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - hmpps-complexity-of-need-{{ checksum "Gemfile.lock" }}
-            - hmpps-complexity-of-need-
-      - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
+      - ruby/install-deps
       - run:
           name: Rubocop
           command: bundle exec rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,4 +347,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.29
+   2.5.13

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,25 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 121,
+      "fingerprint": "edf687f759ec9765bd5db185dbc615c80af77d6e7e19386fc42934e7a80307af",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 3.0.2 ended on 2024-03-31",
+      "file": ".ruby-version",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Ruby will be updated soon, ignoring this brakeman warning for now."
+    }
+  ],
+  "updated": "2024-06-19 15:37:25 +0100",
+  "brakeman_version": "6.1.2"
+}


### PR DESCRIPTION
This will align both projects (MPC and CNL) and also would help us with the ruby/rails upgrade in the future.

Also I would like to see if we can run the tests in the pipeline again, as this was disabled in PR https://github.com/ministryofjustice/hmpps-complexity-of-need/pull/51.

For now I've commented out `rspec` and `undercover` jobs as these will require some additional work, specially the tests seem to be lacking the necessary ENV variable secrets.