### PR TITLE
MO-1518 Fix the 'multiple' endpoint

### DIFF
--- a/Complexity Of Need API Specification.yaml
+++ b/Complexity Of Need API Specification.yaml
@@ -216,6 +216,7 @@ paths:
 
         The response array:
           - will exclude offenders whose Complexity of Need level is not known (i.e. these would result in a `404 Not Found` error on the single `GET` endpoint)
+          - will exclude offenders without a current active level
           - is not sorted in the same order as the request body
           - is not paginated
       parameters: []

--- a/app/controllers/complexities_controller.rb
+++ b/app/controllers/complexities_controller.rb
@@ -17,8 +17,10 @@ class ComplexitiesController < ApplicationController
   def multiple
     return missing_offender_numbers unless params["_json"].is_a? Array
 
-    @complexities = Complexity.latest_for_offenders(params["_json"])
-    Rails.logger.info("ComplexitiesController.multiple: #{@complexities.size} records returned")
+    offender_nos = params["_json"]
+    @complexities = Complexity.latest_for_offenders(offender_nos)
+
+    Rails.logger.info("ComplexitiesController.multiple: #{offender_nos.size} requested / #{@complexities.size} returned")
   end
 
   def history

--- a/app/controllers/complexities_controller.rb
+++ b/app/controllers/complexities_controller.rb
@@ -17,7 +17,7 @@ class ComplexitiesController < ApplicationController
   def multiple
     return missing_offender_numbers unless params["_json"].is_a? Array
 
-    @complexities = Complexity.active.latest_for_offenders(params["_json"])
+    @complexities = Complexity.latest_for_offenders(params["_json"])
     Rails.logger.info("ComplexitiesController.multiple: #{@complexities.size} records returned")
   end
 

--- a/app/models/complexity.rb
+++ b/app/models/complexity.rb
@@ -6,8 +6,6 @@ class Complexity < ApplicationRecord
   end
   VALID_LEVELS = %w[low medium high].freeze
 
-  scope :active, -> { where(active: true) }
-
   validates :offender_no, presence: true
   validates :level, inclusion: {
     in: VALID_LEVELS,

--- a/app/models/complexity.rb
+++ b/app/models/complexity.rb
@@ -17,9 +17,10 @@ class Complexity < ApplicationRecord
 
   # Get the latest/current Complexity for the given offenders
   def self.latest_for_offenders(offender_nos)
-    active
-      .select("DISTINCT ON (offender_no) *")
-      .order(:offender_no, created_at: :desc)
-      .where(offender_no: offender_nos)
+    where(offender_no: offender_nos)
+      .order(created_at: :desc)
+      .group_by(&:offender_no)
+      .transform_values(&:first)
+      .values.select(&:active?)
   end
 end

--- a/deploy/preprod/app-environment.yaml
+++ b/deploy/preprod/app-environment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: app-environment
 data:
   RAILS_ENV: "production"
+  RAILS_LOG_TO_STDOUT: "on"
   SENTRY_CURRENT_ENV: "preprod"
   COMPLEXITY_OF_NEED_HOST: "https://complexity-of-need-preprod.hmpps.service.justice.gov.uk"
   NOMIS_OAUTH_HOST: "https://sign-in-preprod.hmpps.service.justice.gov.uk"

--- a/deploy/production/app-environment.yaml
+++ b/deploy/production/app-environment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: app-environment
 data:
   RAILS_ENV: "production"
+  RAILS_LOG_TO_STDOUT: "on"
   SENTRY_CURRENT_ENV: "production"
   COMPLEXITY_OF_NEED_HOST: "https://complexity-of-need.hmpps.service.justice.gov.uk"
   NOMIS_OAUTH_HOST: "https://sign-in.hmpps.service.justice.gov.uk"

--- a/deploy/staging/shared-environment.yaml
+++ b/deploy/staging/shared-environment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: shared-environment
 data:
   RAILS_ENV: "production"
+  RAILS_LOG_TO_STDOUT: "on"
   SENTRY_CURRENT_ENV: "staging"
   COMPLEXITY_OF_NEED_HOST: "https://hmpps-complexity-of-need-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
   NOMIS_OAUTH_HOST: "https://sign-in-dev.hmpps.service.justice.gov.uk"

--- a/spec/api/v1/rswag_spec.rb
+++ b/spec/api/v1/rswag_spec.rb
@@ -99,6 +99,7 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
 
         The response array:
           - will exclude offenders whose Complexity of Need level is not known (i.e. these would result in a `404 Not Found` error on the single `GET` endpoint)
+          - will exclude offenders without a current active level
           - is not sorted in the same order as the request body
           - is not paginated
       DESC

--- a/spec/factories/complexities.rb
+++ b/spec/factories/complexities.rb
@@ -6,8 +6,6 @@ FactoryBot.define do
     level { Complexity::VALID_LEVELS.sample }
     source_system { "omic-mpc-something" }
     active { true }
-
-    # Complexity records are never edited, so updated_at should always equal created_at
     updated_at { created_at }
 
     trait :with_user do

--- a/spec/models/complexity_spec.rb
+++ b/spec/models/complexity_spec.rb
@@ -78,37 +78,44 @@ RSpec.describe Complexity, type: :model do
   describe ".latest_for_offenders" do
     subject { described_class.latest_for_offenders(offenders) }
 
-    let(:offenders) { [offender_with_multiple_levels, offender_with_one_level, offender_without_levels] }
-    let(:offender_with_multiple_levels) { "Offender1" }
-    let(:offender_with_one_level) { "Offender2" }
-    let(:offender_without_levels) { "Offender3" }
-    let(:some_other_offender) { "Offender4" } # we don't want get this offender's complexity level
+    let(:offenders) { [offender1, offender2, offender3, offender4] }
+
+    let(:offender1) { "A0001BC" }
+    let(:offender2) { "A0002BC" }
+    let(:offender3) { "A0003BC" }
+    let(:offender4) { "A0004BC" }
+    let(:offender5) { "A0005BC" }
 
     before do
-      # Create 10 entries for offender_with_multiple_levels
-      create_list(:complexity, 10, :random_date, offender_no: offender_with_multiple_levels)
+      # Offender 1 has multiple historical levels, but currently no level
+      create(:complexity, :inactive, offender_no: offender1, created_at: Time.zone.today - 5.days)
+      create(:complexity, :inactive, offender_no: offender1, created_at: Time.zone.today - 4.days)
+      create(:complexity,            offender_no: offender1, created_at: Time.zone.today - 3.days)
+      create(:complexity, :inactive, offender_no: offender1, created_at: Time.zone.today - 2.days)
 
-      # Create 1 entry for offender_with_one_level
-      create(:complexity, :random_date, offender_no: offender_with_one_level)
+      # Offender 2 has multiple historical levels, and a current level
+      create(:complexity, :inactive, offender_no: offender2, created_at: Time.zone.today - 5.days)
+      create(:complexity, :inactive, offender_no: offender2, created_at: Time.zone.today - 4.days)
+      create(:complexity,            offender_no: offender2, created_at: Time.zone.today - 3.days)
+      create(:complexity,            offender_no: offender2, created_at: Time.zone.today - 2.days, notes: "2 current")
 
-      # Create nothing for offender_without_levels
+      # Offender 3 has one level, which is current
+      create(:complexity,            offender_no: offender3, created_at: Time.zone.today - 5.days, notes: "3 current")
 
-      # Create entries for some_other_offender
-      create_list(:complexity, 5, :random_date, offender_no: some_other_offender)
+      # Offender 4 has never had a level
+
+      # Offender 5 has one level, which is current, but is not part of the lookup
+      create(:complexity,            offender_no: offender5, created_at: Time.zone.today - 5.days)
     end
 
     it "only returns offenders who have a Complexity level" do
       returned_offenders = subject.map(&:offender_no)
-      expect(returned_offenders).not_to include(offender_without_levels)
-      expect(returned_offenders).to contain_exactly(offender_with_multiple_levels, offender_with_one_level)
+      expect(returned_offenders).to contain_exactly(offender2, offender3)
     end
 
     it "returns the latest/current Complexity level for each offender" do
-      offenders.each do |offender|
-        most_recent = described_class.where(offender_no: offender).order(created_at: :desc).limit(1)
-        actual = subject.select { |complexity| complexity.offender_no == offender }
-        expect(actual).to eq(most_recent)
-      end
+      returned_offenders = subject.map(&:notes)
+      expect(returned_offenders).to contain_exactly("2 current", "3 current")
     end
   end
 end

--- a/spec/requests/v1/complexities_request_spec.rb
+++ b/spec/requests/v1/complexities_request_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe "Complexities", type: :request do
       # rubocop:disable RSpec/NestedGroups
       context "with the latest complexity inactive" do
         let(:most_recent_active_status) { false }
-        let(:most_recent_active) { Complexity.active.where(offender_no: offender_no).order(created_at: :desc).first }
 
         it "returns 404" do
           expect(response).to have_http_status :not_found


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1518

This is a second attempt to fix an issue with the `multiple` endpoint. Previously a [similar approach](https://github.com/ministryofjustice/hmpps-complexity-of-need/pull/87) was taken but PR reverted as the API stopped working, which I believe must have been some unrelated event, not produced by the code changes. **Update**: on second look, issue might have been due to excessive DB queries, one for each offender.

More info:
https://mojdt.slack.com/archives/C03N99X465Q/p1711029843538929
https://mojdt.slack.com/archives/CFNTUQHFE/p1718967060046829

In summary, the `multiple` endpoint was sometimes returning incorrect CNL for some offenders, and the culprit was the DB query scoping by `active: true`, meaning it would be returning ONLY records that are active, and from those, picking the most recent one for each of the offenders passed.

However the most recent record might have been deactivated (as in having no CNL), but the scoping was not returning it.

This PR takes the previous attempt and does the same thing to try to fix the problem, just a slightly different code.
Crucially, removes the previous DB bottleneck, where a query was triggered for each of the offenders (that can be hundreds if not thousands of queries). This could easily deplete the DB pool under normal service load as several users load their allocations simultaneously and end up in timeouts or API errors.