### PR TITLE
MO-1128 Reintroduce running tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ references:
           PGUSER: ubuntu
           RACK_ENV: test
           AWS_DEFAULT_REGION: eu-west-2
-          NOMIS_OAUTH_HOST: https://sign-in-dev.hmpps.service.justice.gov.uk
+          NOMIS_OAUTH_HOST: https://test-auth-service.example.com
+          NOMIS_OAUTH_CLIENT_ID: test-client-id
       - image: circleci/postgres:10.5-alpine
         environment:
           POSTGRES_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ references:
           AWS_DEFAULT_REGION: eu-west-2
           NOMIS_OAUTH_HOST: https://test-auth-service.example.com
           NOMIS_OAUTH_CLIENT_ID: test-client-id
+          MOCK_AUTH: 1
       - image: circleci/postgres:10.5-alpine
         environment:
           POSTGRES_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,16 @@ jobs:
       - run:
           name: Security analysis
           command: bundle exec brakeman -o ~/test-results/brakeman/brakeman.json -o ~/test-results/brakeman/brakeman.html
-#      - run:
-#          name: Run RSpec tests
-#          command: bundle exec rspec --format progress --format RspecJunitFormatter --out ~/rspec/rspec.xml
-#      - store_test_results:
-#          path: ~/rspec
-#      - store_artifacts:
-#          path: coverage
-#      - run:
-#         name: Check code coverage
-#         command: bundle exec undercover --compare origin/main
+      - run:
+          name: Run RSpec tests
+          command: bundle exec rspec --format progress --format RspecJunitFormatter --out ~/rspec/rspec.xml
+      - store_test_results:
+          path: ~/rspec
+      - store_artifacts:
+          path: coverage
+      - run:
+          name: Check code coverage
+          command: bundle exec undercover --compare origin/main
 
   build_and_push_docker_image:
     <<: *defaults

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# Only used for tests - not a real secret for the app
+#
+# Do not put secrets or local config here, this file is committed to git
+# To adapt to your local setup, copy this file to `.env` to make any changes
+#
 NOMIS_OAUTH_CLIENT_ID="offender-management-allocation-manager"
 NOMIS_OAUTH_CLIENT_SECRET="<insert secret here>"
 NOMIS_OAUTH_HOST="https://sign-in-dev.hmpps.service.justice.gov.uk"

--- a/Complexity Of Need API Specification.yaml
+++ b/Complexity Of Need API Specification.yaml
@@ -177,7 +177,7 @@ paths:
         '401':
           description: Invalid or missing access token
         '403':
-          description: Access token is missing scope `read`
+          description: Access token is missing necessary role
         '404':
           description: The Complexity of Need level for this offender is not known
     post:
@@ -199,8 +199,7 @@ paths:
         '401':
           description: Invalid or missing access token
         '403':
-          description: Access token is missing role `ROLE_COMPLEXITY_OF_NEED` or scope
-            `write`
+          description: Access token is missing role `ROLE_COMPLEXITY_OF_NEED`
       requestBody:
         content:
           application/json:
@@ -235,7 +234,7 @@ paths:
         '401':
           description: Invalid or missing access token
         '403':
-          description: Access token is missing scope `read`
+          description: Access token is missing necessary role
       requestBody:
         content:
           application/json:
@@ -274,7 +273,7 @@ paths:
         '401':
           description: Invalid or missing access token
         '403':
-          description: Access token is missing scope `read`
+          description: Access token is missing necessary role
         '404':
           description: The Complexity of Need level for this offender is not known
   "/v1/complexity-of-need/offender-no/{offender_no}/inactivate":
@@ -301,8 +300,7 @@ paths:
         '401':
           description: Invalid or missing access token
         '403':
-          description: Access token is missing role `ROLE_COMPLEXITY_OF_NEED` or scope
-            `write`
+          description: Access token is missing role `ROLE_COMPLEXITY_OF_NEED`
   "/subject-access-request":
     get:
       summary: API call to retrieve SAR data from a product

--- a/app/services/hmpps_api/oauth/token.rb
+++ b/app/services/hmpps_api/oauth/token.rb
@@ -31,10 +31,6 @@ module HmppsApi
         @payload.fetch("authorities", []).include?(role)
       end
 
-      def has_scope?(scope)
-        @payload.fetch("scope", []).include?(scope)
-      end
-
       def self.from_json(payload)
         Token.new(payload.fetch("access_token"))
       end

--- a/spec/api/v1/rswag_spec.rb
+++ b/spec/api/v1/rswag_spec.rb
@@ -26,6 +26,10 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
     get "Retrieve the current Complexity of Need level for an offender" do
       tags "Single Offender"
 
+      before do
+        stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
+      end
+
       response "200", "Offender's current Complexity of Need level found" do
         before do
           create(:complexity, :with_user, offender_no: offender_no)
@@ -42,9 +46,9 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
         run_test!
       end
 
-      response "403", "Access token is missing scope `read`" do
+      response "403", "Access token is missing necessary role" do
         before do
-          stub_access_token scopes: []
+          stub_access_token roles: []
         end
 
         run_test!
@@ -60,6 +64,10 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
       description "Clients calling this endpoint must have role: `ROLE_UPDATE_COMPLEXITY_OF_NEED`"
 
       parameter name: :body, in: :body, schema: { "$ref" => "#/components/schemas/NewComplexityOfNeed" }
+
+      before do
+        stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+      end
 
       response "200", "Complexity of Need level set successfully" do
         schema "$ref" => "#/components/schemas/ComplexityOfNeed"
@@ -81,9 +89,9 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
         run_test!
       end
 
-      response "403", "Access token is missing role `ROLE_COMPLEXITY_OF_NEED` or scope `write`" do
+      response "403", "Access token is missing role `ROLE_COMPLEXITY_OF_NEED`" do
         before do
-          stub_access_token scopes: %w[read], roles: %w[SOME_OTHER_ROLE]
+          stub_access_token roles: %w[SOME_OTHER_ROLE]
         end
 
         run_test!
@@ -92,6 +100,10 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
   end
 
   path "/complexity-of-need/multiple/offender-no" do
+    before do
+      stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
+    end
+
     post "Retrieve the current Complexity of Need levels for multiple offenders" do
       tags "Multiple Offenders"
       description <<~DESC
@@ -129,9 +141,9 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
         run_test!
       end
 
-      response "403", "Access token is missing scope `read`" do
+      response "403", "Access token is missing necessary role" do
         before do
-          stub_access_token scopes: []
+          stub_access_token roles: []
         end
 
         run_test!
@@ -144,6 +156,10 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
               description: "NOMIS Offender Number", example: "A0000AA"
 
     let(:offender_no) { "G4273GI" }
+
+    before do
+      stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
+    end
 
     get "Retrieve full history of Complexity of Needs for an offender" do
       tags "Single Offender"
@@ -166,9 +182,9 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
         run_test!
       end
 
-      response "403", "Access token is missing scope `read`" do
+      response "403", "Access token is missing necessary role" do
         before do
-          stub_access_token scopes: []
+          stub_access_token roles: []
         end
 
         run_test!
@@ -185,6 +201,10 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
               description: "NOMIS Offender Number", example: "A0000AA"
 
     let(:offender_no) { "G4273GI" }
+
+    before do
+      stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+    end
 
     put "Inactivate the Complexity of Need level for an offender" do
       tags "Single Offender"
@@ -206,9 +226,9 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.yaml" do
         run_test!
       end
 
-      response "403", "Access token is missing role `ROLE_COMPLEXITY_OF_NEED` or scope `write`" do
+      response "403", "Access token is missing role `ROLE_COMPLEXITY_OF_NEED`" do
         before do
-          stub_access_token scopes: %w[read], roles: %w[SOME_OTHER_ROLE]
+          stub_access_token roles: %w[SOME_OTHER_ROLE]
         end
 
         run_test!

--- a/spec/auth_helper.rb
+++ b/spec/auth_helper.rb
@@ -21,7 +21,7 @@ module AuthHelper
   def stub_access_token(roles: [])
     token = instance_double(HmppsApi::Oauth::Token, access_token: "dummy-access-token")
     allow(token).to receive(:has_role?) { |role| roles.include?(role) }
-    allow(token).to receive(:client_id) { ENV.fetch("NOMIS_OAUTH_CLIENT_ID") }
+    allow(token).to receive(:client_id) { Rails.configuration.nomis_oauth_client_id }
     allow(HmppsApi::Oauth::Token).to receive(:new).and_return(token)
   end
 

--- a/spec/auth_helper.rb
+++ b/spec/auth_helper.rb
@@ -26,6 +26,10 @@ module AuthHelper
   end
 
   def stub_expired_access_token
-    allow(HmppsApi::Oauth::Token).to receive(:new).and_raise(JWT::ExpiredSignature)
+    if ENV["CIRCLECI"].present?
+      allow(HmppsApi::Oauth::Token).to receive(:new).and_raise(JWT::ExpiredSignature)
+    else
+      allow(HmppsApi::Oauth::Token).to receive(:new).and_call_original
+    end
   end
 end

--- a/spec/auth_helper.rb
+++ b/spec/auth_helper.rb
@@ -8,7 +8,7 @@ module AuthHelper
     # When running tests in CI, we mock auth calls
     # Otherwise, return a valid Authorization HTTP header with a real access token
     # This allows us to test the HMPPS Auth integration
-    if ENV["CIRCLECI"].present?
+    if ENV["MOCK_AUTH"].present?
       allow(oauth_client).to receive(:post).with(route).and_return({ "access_token" => "dummy-access-token" })
     end
 
@@ -26,7 +26,7 @@ module AuthHelper
   end
 
   def stub_expired_access_token
-    if ENV["CIRCLECI"].present?
+    if ENV["MOCK_AUTH"].present?
       allow(HmppsApi::Oauth::Token).to receive(:new).and_raise(JWT::ExpiredSignature)
     else
       allow(HmppsApi::Oauth::Token).to receive(:new).and_call_original

--- a/spec/auth_helper.rb
+++ b/spec/auth_helper.rb
@@ -1,21 +1,31 @@
 # frozen_string_literal: true
 
 module AuthHelper
-  # Return a valid Authorization HTTP header with a real access token
-  # This allows us to test the HMPPS Auth integration
   def auth_header
     oauth_client = HmppsApi::Oauth::Client.new(Rails.configuration.nomis_oauth_host)
     route = "/auth/oauth/token?grant_type=client_credentials"
+
+    # When running tests in CI, we mock auth calls
+    # Otherwise, return a valid Authorization HTTP header with a real access token
+    # This allows us to test the HMPPS Auth integration
+    if ENV["CIRCLECI"].present?
+      allow(oauth_client).to receive(:post).with(route).and_return({ "access_token" => "dummy-access-token" })
+    end
+
     response = oauth_client.post(route)
     access_token = response.fetch("access_token")
     "Bearer #{access_token}"
   end
 
-  # Mock the client's access token with the specified scopes and roles
-  def stub_access_token(scopes: [], roles: [])
+  # Mock the client's access token with the specified roles
+  def stub_access_token(roles: [])
     token = instance_double(HmppsApi::Oauth::Token, access_token: "dummy-access-token")
-    allow(token).to receive(:has_scope?) { |scope| scopes.include?(scope) }
     allow(token).to receive(:has_role?) { |role| roles.include?(role) }
+    allow(token).to receive(:client_id) { ENV.fetch("NOMIS_OAUTH_CLIENT_ID") }
     allow(HmppsApi::Oauth::Token).to receive(:new).and_return(token)
+  end
+
+  def stub_expired_access_token
+    allow(HmppsApi::Oauth::Token).to receive(:new).and_raise(JWT::ExpiredSignature)
   end
 end

--- a/spec/requests/v1/complexities_request_spec.rb
+++ b/spec/requests/v1/complexities_request_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Complexities", type: :request do
     let!(:complexity) { create(:complexity) }
 
     before do
+      stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
       get endpoint, headers: request_headers
     end
 
@@ -104,9 +105,9 @@ RSpec.describe "Complexities", type: :request do
       # rubocop:enable RSpec/NestedGroups
     end
 
-    context "when the client doesn't have the 'read' scope" do
+    context "when the client doesn't have the necessary role" do
       before do
-        stub_access_token scopes: []
+        stub_access_token roles: []
         get endpoint, headers: request_headers
       end
 
@@ -125,6 +126,7 @@ RSpec.describe "Complexities", type: :request do
       before do
         # Travel into the future to expire the access token
         Timecop.travel(Time.zone.today + 1.year) do
+          stub_expired_access_token
           get endpoint, headers: request_headers
         end
       end
@@ -137,6 +139,10 @@ RSpec.describe "Complexities", type: :request do
     let(:endpoint) { "/v1/complexity-of-need/offender-no/#{offender_no}" }
     let(:offender_no) { "ABC123" }
     let(:source_system) { Rails.configuration.nomis_oauth_client_id }
+
+    before do
+      stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+    end
 
     context "with only mandatory fields" do
       let(:post_body) do
@@ -236,7 +242,7 @@ RSpec.describe "Complexities", type: :request do
 
     context "without role ROLE_UPDATE_COMPLEXITY_OF_NEED" do
       before do
-        stub_access_token scopes: %w[read write], roles: %w[ROLE_COMPLEXITY_OF_NEED]
+        stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
         post endpoint, headers: request_headers
       end
 
@@ -256,6 +262,7 @@ RSpec.describe "Complexities", type: :request do
       before do
         # Travel into the future to expire the access token
         Timecop.travel(Time.zone.today + 1.year) do
+          stub_expired_access_token
           post endpoint, headers: request_headers
         end
       end
@@ -266,6 +273,10 @@ RSpec.describe "Complexities", type: :request do
 
   describe "POST /v1/complexity-of-need/multiple/offender-no" do
     let(:endpoint) { "/v1/complexity-of-need/multiple/offender-no" }
+
+    before do
+      stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
+    end
 
     context "with a missing or invalid request body" do
       before do
@@ -333,8 +344,7 @@ RSpec.describe "Complexities", type: :request do
     end
 
     context "with lots of offenders" do
-      # Generate 1000 offender numbers
-      let(:offenders) { (1..1000).map { |n| "Offender#{n}" } }
+      let(:offenders) { (1..400).map { |n| "Offender#{n}" } }
 
       let(:expected_response) do
         offenders.map do |offender|
@@ -364,9 +374,9 @@ RSpec.describe "Complexities", type: :request do
       end
     end
 
-    context "when the client doesn't have the 'read' scope" do
+    context "when the client doesn't have the necessary role" do
       before do
-        stub_access_token scopes: []
+        stub_access_token roles: []
         post endpoint, headers: request_headers
       end
 
@@ -382,11 +392,10 @@ RSpec.describe "Complexities", type: :request do
     end
 
     context "when the client's token has expired" do
-      let(:token_is_expired) { true }
-
       before do
         # Travel into the future to expire the access token
         Timecop.travel(Time.zone.today + 1.year) do
+          stub_expired_access_token
           post endpoint, headers: request_headers
         end
       end
@@ -400,6 +409,7 @@ RSpec.describe "Complexities", type: :request do
     let(:different_offender_no) { "XYZ456" }
 
     before do
+      stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
       get endpoint, headers: request_headers
     end
 
@@ -480,11 +490,11 @@ RSpec.describe "Complexities", type: :request do
       # rubocop:enable RSpec/NestedGroups
     end
 
-    context "when the client doesn't have the 'read' scope" do
+    context "when the client doesn't have the necessary role" do
       let(:offender_no) { "1234567" }
 
       before do
-        stub_access_token scopes: []
+        stub_access_token roles: []
         get endpoint, headers: request_headers
       end
 
@@ -507,6 +517,7 @@ RSpec.describe "Complexities", type: :request do
       before do
         # Travel into the future to expire the access token
         Timecop.travel(Time.zone.today + 1.year) do
+          stub_expired_access_token
           get endpoint, headers: request_headers
         end
       end
@@ -519,6 +530,10 @@ RSpec.describe "Complexities", type: :request do
     let(:endpoint) { "/v1/complexity-of-need/offender-no/#{offender_no}/inactivate" }
     let(:offender_no) { complexity.offender_no }
     let!(:complexity) { create(:complexity) }
+
+    before do
+      stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+    end
 
     context "when authenticated with correct role" do
       before do
@@ -543,7 +558,7 @@ RSpec.describe "Complexities", type: :request do
 
     context "without role ROLE_UPDATE_COMPLEXITY_OF_NEED" do
       before do
-        stub_access_token scopes: %w[read write], roles: %w[ROLE_COMPLEXITY_OF_NEED]
+        stub_access_token roles: %w[ROLE_COMPLEXITY_OF_NEED]
         put endpoint, headers: request_headers
       end
 
@@ -563,6 +578,7 @@ RSpec.describe "Complexities", type: :request do
       before do
         # Travel into the future to expire the access token
         Timecop.travel(Time.zone.today + 1.year) do
+          stub_expired_access_token
           put endpoint, headers: request_headers
         end
       end

--- a/spec/requests/v1/subject_access_request_spec.rb
+++ b/spec/requests/v1/subject_access_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Subject access request", type: :request do
 
     shared_context "with mocked token" do
       before do
-        stub_access_token scopes: %w[read write], roles: %w[ROLE_SAR_DATA_ACCESS]
+        stub_access_token roles: %w[ROLE_SAR_DATA_ACCESS]
         get endpoint, headers: request_headers, params: get_body
       end
     end
@@ -145,7 +145,7 @@ RSpec.describe "Subject access request", type: :request do
 
     context "when the client lacks the ROLE_SAR_DATA_ACCESS role" do
       before do
-        stub_access_token scopes: %w[read write], roles: %w[ROLE_WHATEVER]
+        stub_access_token roles: %w[ROLE_WHATEVER]
         get endpoint, headers: request_headers
       end
 
@@ -153,7 +153,7 @@ RSpec.describe "Subject access request", type: :request do
 
       context "with the role ROLE_CNL_ADMIN" do # rubocop:disable RSpec/NestedGroups
         before do
-          stub_access_token scopes: %w[read write], roles: %w[ROLE_CNL_ADMIN]
+          stub_access_token roles: %w[ROLE_CNL_ADMIN]
           get endpoint, headers: request_headers, params: { prn: offender_no }
         end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1128

As part of PR #51 tests on CI were disabled due to not having necessary secrets available to request a valid jwt token from hmpps auth service.

This is bad practice so we want to reintroduce running tests on CI. In order to do this I'm mocking the auth calls if we are running tests on CI, whereas in local envs it will continue as before, requesting real jwt tokens.
We can also run mocked auth tests locally, if we wanted, with: `MOCK_AUTH=1 bundle exec rspec`

As part of this work I've done a cleanup of any mention to the token "scope" because it was not used in the code, we are only using roles.