### PR TITLE
MO-1521 Use HMPPS CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,18 +220,18 @@ workflows:
           requires:
             - rubocop
             - run_tests
-#          filters:
-#            branches:
-#              only:
-#                - main
-#                - preprod
+          filters:
+            branches:
+              only:
+                - main
+                - preprod
       - deploy_staging:
           requires:
             - build_and_push_image
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
       - deploy_production_approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ references:
     GITHUB_TEAM_NAME_SLUG: offender-management
 
   deploy_container_config: &deploy_container_config
+    working_directory: ~/app
     resource_class: small
     docker:
       - image: ministryofjustice/cloud-platform-tools
@@ -12,6 +13,7 @@ references:
           KUBE_ENV_PRODUCTION_NAMESPACE: hmpps-complexity-of-need-production
 
   test_container_config: &test_container_config
+    working_directory: ~/app
     resource_class: small
     docker:
       - image: cimg/ruby:3.3.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,8 @@ jobs:
     <<: *deploy_container_config
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Kubectl deployment to live cluster staging setup
           command: |
@@ -136,6 +138,8 @@ jobs:
     <<: *deploy_container_config
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Kubectl deployment preprod setup
           command: |
@@ -169,6 +173,8 @@ jobs:
     <<: *deploy_container_config
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Kubectl deployment production setup
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
             kubectl delete job hmpps-complexity-of-need-migration --ignore-not-found
             sed -i -e s/:latest/:${APP_VERSION}/ deploy/staging/deployment.yaml
             sed -i -e s/:latest/:${APP_VERSION}/ deploy/staging/migration-job.yaml
-            kubectl apply --record=false -f ./deploy/staging
+            kubectl apply -f ./deploy/staging
             kubectl annotate deployments/hmpps-complexity-of-need kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
@@ -161,7 +161,7 @@ jobs:
             kubectl delete job rails-db-migration --ignore-not-found
             sed -i -e s/:latest/:${APP_VERSION}/ deploy/preprod/deployment.yaml
             sed -i -e s/:latest/:${APP_VERSION}/ deploy/preprod/migration-job.yaml
-            kubectl apply --record=false -f ./deploy/preprod
+            kubectl apply -f ./deploy/preprod
             kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
@@ -196,7 +196,7 @@ jobs:
             kubectl delete job rails-db-migration --ignore-not-found
             sed -i -e s/:latest/:${APP_VERSION}/ deploy/production/deployment.yaml
             sed -i -e s/:latest/:${APP_VERSION}/ deploy/production/migration-job.yaml
-            kubectl apply --record=false -f ./deploy/production
+            kubectl apply -f ./deploy/production
             kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ version: 2.1
 
 orbs:
   ruby: circleci/ruby@2.1.3
+  hmpps: ministryofjustice/hmpps@9.1.0
 
 jobs:
   install_dependencies:
@@ -128,9 +129,7 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - run:
-          name: Rubocop
-          command: bundle exec rubocop --no-parallel
+      - ruby/rubocop-check
 
   run_tests:
     <<: *defaults
@@ -141,9 +140,7 @@ jobs:
       - run:
           name: Security analysis
           command: bundle exec brakeman -o ~/test-results/brakeman/brakeman.json -o ~/test-results/brakeman/brakeman.html
-      - run:
-          name: Run RSpec tests
-          command: bundle exec rspec --format progress --format RspecJunitFormatter --out ~/rspec/rspec.xml
+      - ruby/rspec-test
 
   build_and_push_docker_image:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,6 @@
 references:
-  defaults: &defaults
-    working_directory: ~/repo
-
   github_team_name_slug: &github_team_name_slug
     GITHUB_TEAM_NAME_SLUG: offender-management
-    QUAYIO_REPO: quay.io/hmpps/hmpps-complexity-of-need
-    REPONAME: hmpps-complexity-of-need
 
   deploy_container_config: &deploy_container_config
     resource_class: small
@@ -62,14 +57,6 @@ references:
         /usr/libexec/gpg-preset-passphrase --preset --passphrase $GPG_PASSPHRASE $GPG_KEY_KEYGRIP_ID
         git-crypt unlock
 
-  install_aws_cli: &install_aws_cli
-    run:
-      name: Set up aws
-      command: |
-        sudo apt-get update
-        sudo apt-get --assume-yes install python3-pip
-        sudo pip3 install awscli
-
   install_yq: &install_yq
     run:
       name: Install yq (YAML parser)
@@ -80,35 +67,6 @@ references:
         VERSION: v4.6.3
         BINARY: yq_linux_amd64
 
-  build_docker_image: &build_docker_image
-    run:
-      name: Build docker image
-      command: |
-        export BUILD_DATE=$(date -Is) >> $BASH_ENV
-        source $BASH_ENV
-        docker build \
-          --build-arg VERSION_NUMBER=${CIRCLE_BUILD_NUM} \
-          --build-arg COMMIT_ID=${CIRCLE_SHA1} \
-          --build-arg BUILD_DATE=${BUILD_DATE} \
-          --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
-          -t app .
-
-  push_docker_image: &push_docker_image
-    run:
-      name: Push docker image
-      command: |
-        set -xeuo pipefail
-        docker login --username "${QUAYIO_USERNAME}" --password "${QUAYIO_PASSWORD}" quay.io
-        docker tag app "${QUAYIO_REPO}:${CIRCLE_SHA1}"
-        docker push "${QUAYIO_REPO}:${CIRCLE_SHA1}"
-
-        if [ "${CIRCLE_BRANCH}" == "main" ]; then
-          docker tag app "${QUAYIO_REPO}:latest"
-          docker push "${QUAYIO_REPO}:latest"
-        fi
-      environment:
-        <<: *github_team_name_slug
-
 version: 2.1
 
 orbs:
@@ -117,14 +75,12 @@ orbs:
 
 jobs:
   install_dependencies:
-    <<: *defaults
     <<: *test_container_config
     steps:
       - checkout
       - ruby/install-deps
 
   rubocop:
-    <<: *defaults
     <<: *test_container_config
     steps:
       - checkout
@@ -132,7 +88,6 @@ jobs:
       - ruby/rubocop-check
 
   run_tests:
-    <<: *defaults
     <<: *test_container_config
     steps:
       - checkout
@@ -141,19 +96,6 @@ jobs:
           name: Security analysis
           command: bundle exec brakeman -o ~/test-results/brakeman/brakeman.json -o ~/test-results/brakeman/brakeman.html
       - ruby/rspec-test
-
-  build_and_push_docker_image:
-    <<: *defaults
-    <<: *test_container_config
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/repo
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - *install_aws_cli
-      - *build_docker_image
-      - *push_docker_image
 
   deploy_staging:
     <<: *deploy_container_config
@@ -173,19 +115,20 @@ jobs:
       - *configure_gpg
       - *decrypt_secrets
       - *install_yq
+      - hmpps/recall_container_image
       - run:
           name: Deploy to staging
           command: |
             kubectl delete job hmpps-complexity-of-need-migration --ignore-not-found
-            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/staging/deployment.yaml
-            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/staging/migration-job.yaml
+            sed -i -e s/:latest/:${APP_VERSION}/ deploy/staging/deployment.yaml
+            sed -i -e s/:latest/:${APP_VERSION}/ deploy/staging/migration-job.yaml
             kubectl apply --record=false -f ./deploy/staging
             kubectl annotate deployments/hmpps-complexity-of-need kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
       - run:
           name: Wait for Kube to spin up new pods
-          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_STAGING_NAMESPACE" "hmpps-complexity-of-need" "$CIRCLE_SHA1"
+          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_STAGING_NAMESPACE" "hmpps-complexity-of-need" "${APP_VERSION}"
 
   deploy_preprod:
     <<: *deploy_container_config
@@ -205,19 +148,20 @@ jobs:
       - *configure_gpg
       - *decrypt_secrets
       - *install_yq
+      - hmpps/recall_container_image
       - run:
           name: Deploy to pre-production
           command: |
             kubectl delete job rails-db-migration --ignore-not-found
-            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/preprod/deployment.yaml
-            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/preprod/migration-job.yaml
+            sed -i -e s/:latest/:${APP_VERSION}/ deploy/preprod/deployment.yaml
+            sed -i -e s/:latest/:${APP_VERSION}/ deploy/preprod/migration-job.yaml
             kubectl apply --record=false -f ./deploy/preprod
             kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
       - run:
           name: Wait for Kube to spin up new pods
-          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PREPROD_NAMESPACE" "hmpps-complexity-of-need" "$CIRCLE_SHA1"
+          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PREPROD_NAMESPACE" "hmpps-complexity-of-need" "${APP_VERSION}"
 
   deploy_production:
     <<: *deploy_container_config
@@ -237,19 +181,20 @@ jobs:
       - *configure_gpg
       - *decrypt_secrets
       - *install_yq
+      - hmpps/recall_container_image
       - run:
           name: Deploy to production
           command: |
             kubectl delete job rails-db-migration --ignore-not-found
-            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/production/deployment.yaml
-            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/production/migration-job.yaml
+            sed -i -e s/:latest/:${APP_VERSION}/ deploy/production/deployment.yaml
+            sed -i -e s/:latest/:${APP_VERSION}/ deploy/production/migration-job.yaml
             kubectl apply --record=false -f ./deploy/production
             kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
           environment:
             <<: *github_team_name_slug
       - run:
           name: Wait for Kube to spin up new pods
-          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PRODUCTION_NAMESPACE" "hmpps-complexity-of-need" "$CIRCLE_SHA1"
+          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PRODUCTION_NAMESPACE" "hmpps-complexity-of-need" "${APP_VERSION}"
 
 workflows:
   build_and_test:
@@ -261,22 +206,24 @@ workflows:
       - run_tests:
           requires:
             - install_dependencies
-      - build_and_push_docker_image:
+      - hmpps/build_docker:
+          name: build_and_push_image
+          persist_container_image: true
           requires:
             - rubocop
             - run_tests
-          filters:
-            branches:
-              only:
-                - main
-                - preprod
+#          filters:
+#            branches:
+#              only:
+#                - main
+#                - preprod
       - deploy_staging:
           requires:
-            - build_and_push_docker_image
-          filters:
-            branches:
-              only:
-                - main
+            - build_and_push_image
+#          filters:
+#            branches:
+#              only:
+#                - main
       - deploy_production_approval:
           type: approval
           requires:
@@ -292,7 +239,7 @@ workflows:
               only: main
       - deploy_preprod:
           requires:
-            - build_and_push_docker_image
+            - build_and_push_image
           filters:
             branches:
               only: preprod

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN \
   && gem update bundler --no-document \
   && apt-get clean
 
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile* .ruby-version ./
 
 RUN bundle install --without development test --jobs 2 --retry 3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ ARG BUILD_NUMBER
 ARG GIT_BRANCH
 ARG GIT_REF
 
-ENV APP_VERSION=${BUILD_NUMBER}
-ENV APP_GIT_BRANCH=${GIT_BRANCH}
-ENV APP_GIT_REF=${GIT_REF}
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV GIT_REF=${GIT_REF}
 
 WORKDIR /app
 
@@ -48,7 +48,7 @@ COPY . /app
 
 # Record the SHA1 git commit reference in /app/RELEASE
 # This file is automatically used by Sentry to track releases
-RUN echo -n "$APP_GIT_REF" > /app/RELEASE
+RUN echo -n "$GIT_REF" > /app/RELEASE
 
 RUN mkdir -p /home/appuser && \
   useradd appuser -u 1001 --user-group --home /home/appuser && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,13 @@ ENV \
   LANGUAGE=en_GB.UTF-8 \
   LC_ALL=en_GB.UTF-8
 
-ARG VERSION_NUMBER
-ARG COMMIT_ID
-ARG BUILD_DATE
-ARG BUILD_TAG
+ARG BUILD_NUMBER
+ARG GIT_BRANCH
+ARG GIT_REF
 
-ENV APPVERSION=${VERSION_NUMBER}
-ENV APP_GIT_COMMIT=${COMMIT_ID}
-ENV APP_BUILD_DATE=${BUILD_DATE}
-ENV APP_BUILD_TAG=${BUILD_TAG}
+ENV APP_VERSION=${BUILD_NUMBER}
+ENV APP_GIT_BRANCH=${GIT_BRANCH}
+ENV APP_GIT_REF=${GIT_REF}
 
 WORKDIR /app
 
@@ -50,7 +48,7 @@ COPY . /app
 
 # Record the SHA1 git commit reference in /app/RELEASE
 # This file is automatically used by Sentry to track releases
-RUN echo -n "$APP_GIT_COMMIT" > /app/RELEASE
+RUN echo -n "$APP_GIT_REF" > /app/RELEASE
 
 RUN mkdir -p /home/appuser && \
   useradd appuser -u 1001 --user-group --home /home/appuser && \

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.3.3"
+ruby File.read(".ruby-version").chomp
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     parallel (1.25.1)
@@ -313,6 +315,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ API Specification [![API docs](https://img.shields.io/badge/API_docs-view-85EA2D
 
 Posted event Specification [![Event docs](https://img.shields.io/badge/Event_docs-view-85EA2D.svg)](https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/ministryofjustice/hmpps-complexity-of-need/main/Complexity%20of%20Need%20Event%20Specification.yaml)
 
-IMPORTANT NOTE: The *run_tests* job has been temporarily removed from `.circleci/config.yml` until the failing authorisation from CircleCI has been fixed, or the authorisation endpoints are mocked out. This means the specs **will not run on CirlceCI** and it is imperative that **all specs be run locally and verified green before pushing commits on your branch or merging your branch to main**.
+The *run_tests* job in `.circleci/config.yml` will mock calls to HMPPS auth.  
+Running tests locally will perform these calls to the real auth service. You can also run the tests locally 
+with mocked calls: `MOCK_AUTH=1 bundle exec rspec`  


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1521

The [HMPPS orb](https://circleci.com/developer/orbs/orb/ministryofjustice/hmpps) contains many useful jobs and commands to DRY the circle config and make consistent docker images, etc.

We can't use it yet to perform the actual deploys, as the orb is coupled to Helm and expects helm charts to be in a specific directory etc.

For now the orb is used to build/push the docker image. There is some config duplication that will be removed once we can also use the orb for deploys. It is not worth it trying to abstract this now if we intend to use Helm.