### PR TITLE
MO-1519 Helm chart and hmpps orb for deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,40 +210,48 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - install_dependencies:
+#      - install_dependencies:
+#          <<: *ignore_deployable_branches
+#      - rubocop:
+#          requires:
+#            - install_dependencies
+#      - run_tests:
+#          requires:
+#            - install_dependencies
+      - hmpps/helm_lint:
           <<: *ignore_deployable_branches
-      - rubocop:
-          requires:
-            - install_dependencies
-      - run_tests:
-          requires:
-            - install_dependencies
-      - hmpps/build_docker:
-          <<: *ignore_deployable_branches
-          name: verify_docker_image
-          publish: false
+          name: helm_lint
+          env: staging
+#      - hmpps/build_docker:
+#          <<: *ignore_deployable_branches
+#          name: verify_docker_image
+#          publish: false
       - hmpps/build_docker:
           name: build_and_push_image
           persist_container_image: true
-          filters: { branches: { only: [ main, staging, preprod ] } }
-      - deploy_staging:
+          # filters: { branches: { only: [ main, staging, preprod ] } }
+      - hmpps/deploy_env:
+          name: deploy_staging
+          env: staging
+          context: hmpps-complexity-of-need-staging
           requires:
+            - helm_lint
             - build_and_push_image
-          filters: { branches: { only: [ main, staging ] } }
-      - deploy_preprod:
-          requires:
-            - build_and_push_image
-          filters: { branches: { only: [ main, preprod ] } }
-      - deploy_production_approval:
-          type: approval
-          requires:
-            - deploy_staging
-          filters:
-            branches:
-              only: main
-      - deploy_production:
-          requires:
-            - deploy_production_approval
-          filters:
-            branches:
-              only: main
+          # filters: { branches: { only: [ main, staging ] } }
+#      - deploy_preprod:
+#          requires:
+#            - build_and_push_image
+#          filters: { branches: { only: [ main, preprod ] } }
+#      - deploy_production_approval:
+#          type: approval
+#          requires:
+#            - deploy_staging
+#          filters:
+#            branches:
+#              only: main
+#      - deploy_production:
+#          requires:
+#            - deploy_production_approval
+#          filters:
+#            branches:
+#              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,19 +2,6 @@ references:
   ignore_deployable_branches: &ignore_deployable_branches
     filters: { branches: { ignore: [ main, staging, preprod ] } }
 
-  github_team_name_slug: &github_team_name_slug
-    GITHUB_TEAM_NAME_SLUG: offender-management
-
-  deploy_container_config: &deploy_container_config
-    working_directory: ~/app
-    resource_class: small
-    docker:
-      - image: ministryofjustice/cloud-platform-tools
-        environment:
-          KUBE_ENV_STAGING_NAMESPACE: hmpps-complexity-of-need-staging
-          KUBE_ENV_PREPROD_NAMESPACE: hmpps-complexity-of-need-preprod
-          KUBE_ENV_PRODUCTION_NAMESPACE: hmpps-complexity-of-need-production
-
   test_container_config: &test_container_config
     working_directory: ~/app
     resource_class: small
@@ -34,43 +21,6 @@ references:
           POSTGRES_USER: ubuntu
           POSTGRES_PASSWORD: ""
           POSTGRES_DB: hmpps_complexity_of_need_test
-
-  install_gpg: &install_gpg
-    run:
-      name: Install GPG
-      command: |
-        apk add \
-          --no-cache \
-          --no-progress \
-          gnupg
-
-  configure_gpg: &configure_gpg
-    run:
-      name: Configure GPG
-      command: |
-        echo "${GPG_PRIVATE_KEY}" | base64 -d | gpg --batch --allow-secret-key-import --import
-
-  decrypt_secrets: &decrypt_secrets
-    run:
-      name: Decrypt secrets file
-      command: |
-        gpg --export-ownertrust > /tmp/ownertrust.txt
-        echo $GPG_KEY_ID:1 >> /tmp/ownertrust.txt
-        gpg --import-ownertrust /tmp/ownertrust.txt
-        gpgconf --kill gpg-agent
-        gpg-agent --daemon --allow-preset-passphrase
-        /usr/libexec/gpg-preset-passphrase --preset --passphrase $GPG_PASSPHRASE $GPG_KEY_KEYGRIP_ID
-        git-crypt unlock
-
-  install_yq: &install_yq
-    run:
-      name: Install yq (YAML parser)
-      command: |
-        wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -O - |\
-        tar xz && mv ${BINARY} /usr/bin/yq
-      environment:
-        VERSION: v4.6.3
-        BINARY: yq_linux_amd64
 
 version: 2.1
 
@@ -101,111 +51,6 @@ jobs:
           name: Security analysis
           command: bundle exec brakeman -o ~/test-results/brakeman/brakeman.json -o ~/test-results/brakeman/brakeman.html
       - ruby/rspec-test
-
-  deploy_staging:
-    <<: *deploy_container_config
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Kubectl deployment to live cluster staging setup
-          command: |
-            echo -n ${CLUSTER_LIVE_CERT} | base64 -d > ./live_ca.crt
-            kubectl config set-cluster ${CLUSTER_NAME_LIVE} --certificate-authority=./live_ca.crt --server=https://${CLUSTER_NAME_LIVE}
-            kubectl config set-credentials circleci --token=${LIVE_STAGING_TOKEN}
-            kubectl config set-context ${CLUSTER_NAME_LIVE} --cluster=${CLUSTER_NAME_LIVE} --user=circleci --namespace=${KUBE_ENV_STAGING_NAMESPACE}
-            kubectl config use-context ${CLUSTER_NAME_LIVE}
-            kubectl config current-context
-            kubectl --namespace=${KUBE_ENV_STAGING_NAMESPACE} get pods
-      - *install_gpg
-      - *configure_gpg
-      - *decrypt_secrets
-      - *install_yq
-      - hmpps/recall_container_image
-      - run:
-          name: Deploy to staging
-          command: |
-            kubectl delete job hmpps-complexity-of-need-migration --ignore-not-found
-            sed -i -e s/:latest/:${APP_VERSION}/ deploy/staging/deployment.yaml
-            sed -i -e s/:latest/:${APP_VERSION}/ deploy/staging/migration-job.yaml
-            kubectl apply -f ./deploy/staging
-            kubectl annotate deployments/hmpps-complexity-of-need kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
-          environment:
-            <<: *github_team_name_slug
-      - run:
-          name: Wait for Kube to spin up new pods
-          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_STAGING_NAMESPACE" "hmpps-complexity-of-need" "${APP_VERSION}"
-
-  deploy_preprod:
-    <<: *deploy_container_config
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Kubectl deployment preprod setup
-          command: |
-            echo -n ${CLUSTER_LIVE_CERT} | base64 -d > ./live_ca.crt
-            kubectl config set-cluster ${CLUSTER_NAME_LIVE} --certificate-authority=./live_ca.crt --server=https://${CLUSTER_NAME_LIVE}
-            kubectl config set-credentials circleci --token=${LIVE_PREPROD_TOKEN}
-            kubectl config set-context ${CLUSTER_NAME_LIVE} --cluster=${CLUSTER_NAME_LIVE} --user=circleci --namespace=${KUBE_ENV_PREPROD_NAMESPACE}
-            kubectl config use-context ${CLUSTER_NAME_LIVE}
-            kubectl config current-context
-            kubectl --namespace=${KUBE_ENV_PREPROD_NAMESPACE} get pods
-      - *install_gpg
-      - *configure_gpg
-      - *decrypt_secrets
-      - *install_yq
-      - hmpps/recall_container_image
-      - run:
-          name: Deploy to pre-production
-          command: |
-            kubectl delete job rails-db-migration --ignore-not-found
-            sed -i -e s/:latest/:${APP_VERSION}/ deploy/preprod/deployment.yaml
-            sed -i -e s/:latest/:${APP_VERSION}/ deploy/preprod/migration-job.yaml
-            kubectl apply -f ./deploy/preprod
-            kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
-          environment:
-            <<: *github_team_name_slug
-      - run:
-          name: Wait for Kube to spin up new pods
-          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PREPROD_NAMESPACE" "hmpps-complexity-of-need" "${APP_VERSION}"
-
-  deploy_production:
-    <<: *deploy_container_config
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Kubectl deployment production setup
-          command: |
-            echo -n ${CLUSTER_LIVE_CERT} | base64 -d > ./live_ca.crt
-            kubectl config set-cluster ${CLUSTER_NAME_LIVE} --certificate-authority=./live_ca.crt --server=https://${CLUSTER_NAME_LIVE}
-            kubectl config set-credentials circleci --token=${LIVE_PRODUCTION_TOKEN}
-            kubectl config set-context ${CLUSTER_NAME_LIVE} --cluster=${CLUSTER_NAME_LIVE} --user=circleci --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE}
-            kubectl config use-context ${CLUSTER_NAME_LIVE}
-            kubectl config current-context
-            kubectl --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} get pods
-      - *install_gpg
-      - *configure_gpg
-      - *decrypt_secrets
-      - *install_yq
-      - hmpps/recall_container_image
-      - run:
-          name: Deploy to production
-          command: |
-            kubectl delete job rails-db-migration --ignore-not-found
-            sed -i -e s/:latest/:${APP_VERSION}/ deploy/production/deployment.yaml
-            sed -i -e s/:latest/:${APP_VERSION}/ deploy/production/migration-job.yaml
-            kubectl apply -f ./deploy/production
-            kubectl annotate deployments/app-deployment kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
-          environment:
-            <<: *github_team_name_slug
-      - run:
-          name: Wait for Kube to spin up new pods
-          command: bash .circleci/wait-for-successful-deployment.sh "$KUBE_ENV_PRODUCTION_NAMESPACE" "hmpps-complexity-of-need" "${APP_VERSION}"
 
 workflows:
   build_and_test:
@@ -246,16 +91,14 @@ workflows:
             - helm_lint
             - build_and_push_image
           # filters: { branches: { only: [ main, preprod ] } }
-#      - deploy_production_approval:
-#          type: approval
-#          requires:
-#            - deploy_staging
-#          filters:
-#            branches:
-#              only: main
-#      - deploy_production:
-#          requires:
-#            - deploy_production_approval
-#          filters:
-#            branches:
-#              only: main
+      - deploy_production_approval:
+          type: approval
+          requires:
+            - deploy_staging
+          # filters: { branches: { only: [ main ] } }
+      - hmpps/deploy_env:
+          name: deploy_production
+          env: production
+          context: hmpps-complexity-of-need-production
+          requires:
+            - deploy_production_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,9 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_staging
           env: staging
-          context: hmpps-complexity-of-need-staging
+          context:
+            - hmpps-common-vars
+            - hmpps-complexity-of-need-staging
           requires:
             - helm_lint
             - build_and_push_image
@@ -86,7 +88,9 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_preprod
           env: preprod
-          context: hmpps-complexity-of-need-preprod
+          context:
+            - hmpps-common-vars
+            - hmpps-complexity-of-need-preprod
           requires:
             - helm_lint
             - build_and_push_image
@@ -99,6 +103,8 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_production
           env: production
-          context: hmpps-complexity-of-need-production
+          context:
+            - hmpps-common-vars
+            - hmpps-complexity-of-need-production
           requires:
             - deploy_production_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,10 +238,14 @@ workflows:
             - helm_lint
             - build_and_push_image
           # filters: { branches: { only: [ main, staging ] } }
-#      - deploy_preprod:
-#          requires:
-#            - build_and_push_image
-#          filters: { branches: { only: [ main, preprod ] } }
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: preprod
+          context: hmpps-complexity-of-need-preprod
+          requires:
+            - helm_lint
+            - build_and_push_image
+          # filters: { branches: { only: [ main, preprod ] } }
 #      - deploy_production_approval:
 #          type: approval
 #          requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,26 +55,27 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-#      - install_dependencies:
-#          <<: *ignore_deployable_branches
-#      - rubocop:
-#          requires:
-#            - install_dependencies
-#      - run_tests:
-#          requires:
-#            - install_dependencies
+      - install_dependencies:
+          <<: *ignore_deployable_branches
+      - rubocop:
+          requires:
+            - install_dependencies
+      - run_tests:
+          requires:
+            - install_dependencies
       - hmpps/helm_lint:
           <<: *ignore_deployable_branches
           name: helm_lint
           env: staging
-#      - hmpps/build_docker:
-#          <<: *ignore_deployable_branches
-#          name: verify_docker_image
-#          publish: false
+      - hmpps/build_docker:
+          name: verify_docker_image
+          publish: false
+          requires:
+            - helm_lint
       - hmpps/build_docker:
           name: build_and_push_image
           persist_container_image: true
-          # filters: { branches: { only: [ main, staging, preprod ] } }
+          filters: { branches: { only: [ main, staging, preprod ] } }
       - hmpps/deploy_env:
           name: deploy_staging
           env: staging
@@ -82,9 +83,8 @@ workflows:
             - hmpps-common-vars
             - hmpps-complexity-of-need-staging
           requires:
-            - helm_lint
             - build_and_push_image
-          # filters: { branches: { only: [ main, staging ] } }
+          filters: { branches: { only: [ main, staging ] } }
       - hmpps/deploy_env:
           name: deploy_preprod
           env: preprod
@@ -92,14 +92,13 @@ workflows:
             - hmpps-common-vars
             - hmpps-complexity-of-need-preprod
           requires:
-            - helm_lint
             - build_and_push_image
-          # filters: { branches: { only: [ main, preprod ] } }
+          filters: { branches: { only: [ main, preprod ] } }
       - deploy_production_approval:
           type: approval
           requires:
             - deploy_staging
-          # filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ main ] } }
       - hmpps/deploy_env:
           name: deploy_production
           env: production
@@ -108,3 +107,5 @@ workflows:
             - hmpps-complexity-of-need-production
           requires:
             - deploy_production_approval
+          slack_notification: true
+          slack_channel_name: the_elephants_devs

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+Brewfile
+README.md
+.env*
+
+deploy/
+helm_deploy/
+log/
+tmp/
+coverage/
+vendor/bundle/
+.git/
+.bundle/
+.idea
+.github
+.git-crypt/

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,8 @@ Brewfile.lock.json
 # Ignore Simplecov coverage reports
 /coverage
 
+# Helm
+**/Chart.lock
+**/charts/*.tgz
+
 .DS_Store

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,7 +24,7 @@ port ENV.fetch("PORT", 3000)
 environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
+pidfile ENV.fetch("PIDFILE", "/tmp/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/helm_deploy/README.md
+++ b/helm_deploy/README.md
@@ -1,0 +1,69 @@
+# Deployment Notes
+
+## Prerequisites
+
+- Ensure you have Helm v3.x client installed.
+
+```sh
+$ helm version
+version.BuildInfo{Version:"v3.15.2", GitCommit:"1a500d5625419a524fdae4b33de351cc4f58ec35", GitTreeState:"clean", GoVersion:"go1.22.4"}
+```
+
+- Ensure a TLS cert for your intended hostname is configured and ready, see section below.
+
+### Useful helm (v3) commands:
+
+__Test chart template rendering:__
+
+This will out the fully rendered kubernetes resources in raw yaml.
+
+```sh
+helm template [path to chart] --values=path/to/values-dev.yaml
+```
+
+__List releases:__
+
+```sh
+helm --namespace [namespace] list
+```
+
+__List current and previously installed application versions:__
+
+```sh
+helm --namespace [namespace] history [release name]
+```
+
+__Rollback to previous version:__
+
+```sh
+helm --namespace [namespace] rollback [release name] [revision number] --wait
+```
+
+Note: replace _revision number_ with one from listed in the `history` command)
+
+__Example deploy command:__
+
+The following example is `--dry-run` mode - which will allow for testing. CircleCI normally runs this command with actual secret values (from AWS secret manager), and also updated the chart's application version to match the release version:
+
+```sh
+helm upgrade [release name] [path to chart]. \
+  --install --wait --force --reset-values --timeout 5m --history-max 10 \
+  --dry-run \
+  --namespace [namespace] \
+  --values values-dev.yaml \
+  --values example-secrets.yaml
+```
+
+### Ingress TLS certificate
+
+Ensure a certificate definition exists in the cloud-platform-environments repo under the relevant namespaces folder:
+
+e.g.
+
+```sh
+cloud-platform-environments/namespaces/live.cloud-platform.service.justice.gov.uk/[INSERT NAMESPACE NAME]/05-certificate.yaml
+```
+
+Ensure the certificate is created and ready for use.
+
+The name of the kubernetes secret where the certificate is stored is used as a value to the helm chart - this is used to configured the ingress.

--- a/helm_deploy/README.md
+++ b/helm_deploy/README.md
@@ -1,17 +1,53 @@
 # Deployment Notes
 
-## Prerequisites
+## Configure ENV variables in CircleCI
 
-- Ensure you have Helm v3.x client installed.
+In order to perform deploys through CircleCI, the following ENV variables must be configured:
+
+__Common variables__
+
+These are added in [Project Settings > Environment Variables](https://app.circleci.com/settings/project/github/ministryofjustice/hmpps-complexity-of-need/environment-variables)
+and are common to any deploy environment (staging, preprod, production...)
+
+1. `KUBE_ENV_API` with value `https://DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`
+2. `KUBE_ENV_NAME` with value `DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`
+
+__Namespace-dependent variables__
+
+A context needs to be created for each of the deployment envs (so one for staging, another for preprod, etc.)
+
+1. Go to [Contexts for the Ministry of Justice's CircleCI organisation](https://app.circleci.com/settings/organization/github/ministryofjustice/contexts).
+2. Click on "Create Context" button.
+3. Name the context using the name of this project and the name of the environment: `hmpps-complexity-of-need-<environment>` e.g. `hmpps-complexity-of-need-staging`.
+4. Click on "Add Environment Variable" button.
+5. Add an environment variable called `KUBE_ENV_NAMESPACE` and set the value to the Kubernetes namespace for the environment e.g. `hmpps-complexity-of-need-staging`.
+6. Using the command line, list the name of all the secrets within the Kubernetes namespace for the environment.
+    ```bash
+    kubectl get secrets -n <namespace>
+    # E.g. kubectl get secrets -n hmpps-complexity-of-need-staging
+    ```
+7. Using the name of the CircleCI service account secret, retrieve the token for it.
+    ```bash
+    cloud-platform decode-secret -s <circleci-token-secret-name> -n <namespace> | jq -r '.data."token"'
+    # E.g. cloud-platform decode-secret -s circleci-token-z123 -n hmpps-complexity-of-need-staging | jq -r '.data."token"'
+    ```
+8. Add an environment variable called `KUBE_ENV_TOKEN` and set the value to the response of the previous command.
+9. Using the command-line, retrieve the CA certificate for the CircleCI service account.
+    ```bash
+    kubectl get secrets <circleci-token-secret-name> -n <namespace> -o json | jq -r '.data."ca.crt"'
+    # E.g. kubectl get secrets circleci-token-z123 -n hmpps-complexity-of-need-staging -o json | jq -r '.data."ca.crt"'
+    ```
+10. Add an environment variable called `KUBE_ENV_CACERT` and set the value to the response of the previous command.
+11. Repeat these steps for all of the environments required (preprod, production...), adding a new context for each one with their corresponding environment variables.
+
+## Useful helm (v3) commands:
+
+__Ensure you have Helm v3.x client installed:__
 
 ```sh
 $ helm version
 version.BuildInfo{Version:"v3.15.2", GitCommit:"1a500d5625419a524fdae4b33de351cc4f58ec35", GitTreeState:"clean", GoVersion:"go1.22.4"}
 ```
-
-- Ensure a TLS cert for your intended hostname is configured and ready, see section below.
-
-### Useful helm (v3) commands:
 
 __Test chart template rendering:__
 
@@ -24,46 +60,31 @@ helm template [path to chart] --values=path/to/values-dev.yaml
 __List releases:__
 
 ```sh
-helm --namespace [namespace] list
+helm list -n [namespace]
 ```
 
 __List current and previously installed application versions:__
 
 ```sh
-helm --namespace [namespace] history [release name]
+helm history [release name] -n [namespace]
 ```
 
 __Rollback to previous version:__
 
 ```sh
-helm --namespace [namespace] rollback [release name] [revision number] --wait
+helm rollback [release name] [revision number] -n [namespace] --wait
 ```
 
 Note: replace _revision number_ with one from listed in the `history` command)
 
 __Example deploy command:__
 
-The following example is `--dry-run` mode - which will allow for testing. CircleCI normally runs this command with actual secret values (from AWS secret manager), and also updated the chart's application version to match the release version:
+The following example is `--dry-run` mode - which will allow for testing. CircleCI normally runs this command with actual secret values (from AWS secret manager), and also updates the chart's application version to match the release version:
 
 ```sh
-helm upgrade [release name] [path to chart]. \
+helm upgrade [release name] [path to chart] \
   --install --wait --force --reset-values --timeout 5m --history-max 10 \
   --dry-run \
   --namespace [namespace] \
-  --values values-dev.yaml \
-  --values example-secrets.yaml
+  --values path/to/values-staging.yaml
 ```
-
-### Ingress TLS certificate
-
-Ensure a certificate definition exists in the cloud-platform-environments repo under the relevant namespaces folder:
-
-e.g.
-
-```sh
-cloud-platform-environments/namespaces/live.cloud-platform.service.justice.gov.uk/[INSERT NAMESPACE NAME]/05-certificate.yaml
-```
-
-Ensure the certificate is created and ready for use.
-
-The name of the kubernetes secret where the certificate is stored is used as a value to the helm chart - this is used to configured the ingress.

--- a/helm_deploy/hmpps-complexity-of-need/.helmignore
+++ b/helm_deploy/hmpps-complexity-of-need/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+.helmignore
+README.md
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm_deploy/hmpps-complexity-of-need/Chart.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+appVersion: 1.0.0
+type: application
+name: hmpps-complexity-of-need
+description: A Helm chart for Kubernetes
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+dependencies:
+  - name: generic-service
+    version: ~3.3.1
+    repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-complexity-of-need/templates/migration-job.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/templates/migration-job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hmpps-complexity-of-need-migration
+spec:
+  ttlSecondsAfterFinished: 3600
+  completions: 1
+  parallelism: 1
+  backoffLimit: 4
+  template:
+    spec:
+      serviceAccountName: {{ with index .Values "generic-service" }}{{ .serviceAccountName }}{{ end }}
+      restartPolicy: Never
+      containers:
+      - name: hmpps-complexity-of-need-migration
+        image: {{ with index .Values "generic-service" }}{{ .image.repository }}:{{ .image.tag }}{{ end }}
+        imagePullPolicy: Always
+        command: ['sh', '-c', 'bundle exec rails db:migrate && bundle exec rails db:seed']
+          {{- include "deployment.envs" (index .Values "generic-service") | nindent 8 }}
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 50m
+          requests:
+            memory: 1Gi
+            cpu: 30m

--- a/helm_deploy/hmpps-complexity-of-need/templates/migration-job.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/templates/migration-job.yaml
@@ -11,10 +11,14 @@ spec:
     spec:
       serviceAccountName: {{ with index .Values "generic-service" }}{{ .serviceAccountName }}{{ end }}
       restartPolicy: Never
+      securityContext:
+        {{- with index .Values "generic-service" }}{{ toYaml .podSecurityContext | nindent 8 }}{{ end }}
       containers:
       - name: hmpps-complexity-of-need-migration
         image: {{ with index .Values "generic-service" }}{{ .image.repository }}:{{ .image.tag }}{{ end }}
         imagePullPolicy: Always
+        securityContext:
+          {{- with index .Values "generic-service" }}{{ toYaml .securityContext | nindent 10 }}{{ end }}
         command: ['sh', '-c', 'bundle exec rails db:migrate && bundle exec rails db:seed']
           {{- include "deployment.envs" (index .Values "generic-service") | nindent 8 }}
         resources:

--- a/helm_deploy/hmpps-complexity-of-need/templates/migration-job.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/templates/migration-job.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hmpps-complexity-of-need-migration
+  name: rails-db-migration
 spec:
-  ttlSecondsAfterFinished: 3600
+  ttlSecondsAfterFinished: 120
   completions: 1
   parallelism: 1
   backoffLimit: 4
@@ -23,8 +23,8 @@ spec:
           {{- include "deployment.envs" (index .Values "generic-service") | nindent 8 }}
         resources:
           limits:
-            memory: 1Gi
-            cpu: 50m
+            memory: 1000Mi
+            cpu: 1000m
           requests:
-            memory: 1Gi
-            cpu: 30m
+            memory: 500Mi
+            cpu: 50m

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -25,10 +25,8 @@ generic-service:
     enabled: true
 
   # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
-  #  allowlist:
-  #    groups:
-  #      - digital_staff_and_mojo
-  #      - moj_cloud_platform
+  allowlist:
+    custom-1: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,35.176.93.186/32"
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -21,7 +21,7 @@ generic-service:
     port: 3000
 
   ingress:
-    enabled: true
+    enabled: false
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -25,12 +25,12 @@ generic-service:
 
   livenessProbe:
     httpGet:
-      path: /ping
+      path: /health
     periodSeconds: 60
 
   readinessProbe:
     httpGet:
-      path: /ping
+      path: /health
     periodSeconds: 60
 
   podSecurityContext:

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -26,7 +26,9 @@ generic-service:
 
   # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
   allowlist:
-    custom-1: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,35.176.93.186/32"
+    global-protect-3: "35.176.93.186/32"
+    groups:
+      - moj_cloud_platform
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -62,10 +62,10 @@ generic-service:
     app-environment-secrets:
       SECRET_KEY_BASE: SECRET_KEY_BASE
       SENTRY_DSN: SENTRY_DSN
-    hmpps-complexity-of-need-rds-instance-output:
-      POSTGRES_HOST: postgres_host
-      POSTGRES_PASSWORD: postgres_password
-      POSTGRES_NAME: postgres_name
-      POSTGRES_USER: postgres_user
+    rds-instance-output:
+      POSTGRES_HOST: rds_instance_address
+      POSTGRES_USER: database_username
+      POSTGRES_PASSWORD: database_password
+      POSTGRES_NAME: database_name
     hmpps-domain-events-topic:
       DOMAIN_EVENTS_TOPIC_ARN: topic_arn

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -25,10 +25,10 @@ generic-service:
     enabled: true
 
   # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
-  allowlist:
-    global-protect-3: 35.176.93.186/32
-    groups:
-      - moj_cloud_platform
+  #  allowlist:
+  #    groups:
+  #      - digital_staff_and_mojo
+  #      - moj_cloud_platform
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -15,13 +15,20 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-complexity-of-need
+    tag: app_version # overridden at deployment time
     port: 3000
 
   service:
     port: 3000
 
   ingress:
-    enabled: false
+    enabled: true
+
+  # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
+  allowlist:
+    global-protect-3: 35.176.93.186/32
+    groups:
+      - moj_cloud_platform
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/hmpps-complexity-of-need/values.yaml
+++ b/helm_deploy/hmpps-complexity-of-need/values.yaml
@@ -1,0 +1,71 @@
+---
+# Default values.
+# Declare variables to be passed into your templates.
+#
+# Variables in `helm_deploy/values-[env].yaml` will take precedence.
+
+generic-service:
+  replicaCount: 2
+
+  nameOverride: hmpps-complexity-of-need
+  serviceAccountName: hmpps-complexity-of-need
+  productId: DPS030
+
+  containerCommand: ['sh', '-c', 'bundle exec puma']
+
+  image:
+    repository: quay.io/hmpps/hmpps-complexity-of-need
+    port: 3000
+
+  service:
+    port: 3000
+
+  ingress:
+    enabled: true
+
+  livenessProbe:
+    httpGet:
+      path: /ping
+    periodSeconds: 60
+
+  readinessProbe:
+    httpGet:
+      path: /ping
+    periodSeconds: 60
+
+  podSecurityContext:
+    fsGroup: 1001
+
+  securityContext:
+    runAsUser: 1001
+    runAsNonRoot: true
+
+  resources:
+    limits:
+      memory: 1000Mi
+      cpu: 1000m
+    requests:
+      memory: 500Mi
+      cpu: 50m
+
+  # Environment variables to load into the deployment
+  env:
+    RAILS_ENV: production
+    RAILS_LOG_TO_STDOUT: on
+    LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so
+
+  # Pre-existing kubernetes secrets to load as environment variables in the deployment.
+  # namespace_secrets:
+  #   [name of kubernetes secret]:
+  #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
+  namespace_secrets:
+    app-environment-secrets:
+      SECRET_KEY_BASE: SECRET_KEY_BASE
+      SENTRY_DSN: SENTRY_DSN
+    hmpps-complexity-of-need-rds-instance-output:
+      POSTGRES_HOST: postgres_host
+      POSTGRES_PASSWORD: postgres_password
+      POSTGRES_NAME: postgres_name
+      POSTGRES_USER: postgres_user
+    hmpps-domain-events-topic:
+      DOMAIN_EVENTS_TOPIC_ARN: topic_arn

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,0 +1,11 @@
+---
+generic-service:
+  ingress:
+    hosts:
+      - complexity-of-need-preprod.hmpps.service.justice.gov.uk
+    tlsSecretName: preprod-cert
+
+  env:
+    SENTRY_CURRENT_ENV: preprod
+    COMPLEXITY_OF_NEED_HOST: https://complexity-of-need-preprod.hmpps.service.justice.gov.uk
+    NOMIS_OAUTH_HOST: https://sign-in-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -1,0 +1,11 @@
+---
+generic-service:
+  ingress:
+    hosts:
+      - complexity-of-need.hmpps.service.justice.gov.uk
+    tlsSecretName: production-cert
+
+  env:
+    SENTRY_CURRENT_ENV: production
+    COMPLEXITY_OF_NEED_HOST: https://complexity-of-need.hmpps.service.justice.gov.uk
+    NOMIS_OAUTH_HOST: https://sign-in.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -1,0 +1,11 @@
+---
+generic-service:
+  ingress:
+    hosts:
+      - complexity-of-need-staging.hmpps.service.justice.gov.uk
+    tlsSecretName: staging-cert
+
+  env:
+    SENTRY_CURRENT_ENV: staging
+    COMPLEXITY_OF_NEED_HOST: https://complexity-of-need-staging.hmpps.service.justice.gov.uk
+    NOMIS_OAUTH_HOST: https://sign-in-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -5,6 +5,8 @@ generic-service:
       - complexity-of-need-staging.hmpps.service.justice.gov.uk
     tlsSecretName: staging-cert
 
+  allowlist: null
+
   env:
     SENTRY_CURRENT_ENV: staging
     COMPLEXITY_OF_NEED_HOST: https://complexity-of-need-staging.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1519

Migrate existing kubernetes files to HMPPS Helm chart. With this PR we can also use the deploy jobs from the HMPPS CircleCI orb (I've updated the circle config for this).

Given the nature of this work, I've been triggering deploys to staging, preprod and finally early this morning to production to ensure everything was working as expected, so merging this PR will not have any effect as Helm chart is already in place in all environments.

NOTE: in a separate PR I will cleanup old kubernetes files, git-crypt, etc.