### PR TITLE
MO-1541 Add info endpoint

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class InfoController < ApplicationController
+  BUILD_NAME = "hmpps-complexity-of-need"
+
+  def index
+    render json: {
+      git: {
+        branch: ENV["GIT_BRANCH"],
+      },
+      build: {
+        artifact: BUILD_NAME,
+        version: ENV["BUILD_NUMBER"],
+        name: BUILD_NAME,
+      },
+      productId: ENV["PRODUCT_ID"],
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   get "/ping" => "health#index"
   get "/health" => "health#index"
+  get "/info" => "info#index"
 
   # Default the request format to JSON – avoids need for .json file extension on paths
   defaults format: :json do

--- a/spec/requests/info_spec.rb
+++ b/spec/requests/info_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Info endpoints" do
+  describe "GET /info" do
+    before do
+      stub_const(
+        "ENV", {
+          "GIT_BRANCH" => "main",
+          "BUILD_NUMBER" => "af79nbc",
+          "PRODUCT_ID" => "PROD1",
+        }
+      )
+
+      get "/info"
+    end
+
+    it "returns information regarding the deployed application" do
+      expect(
+        response.body,
+      ).to eq('{"git":{"branch":"main"},"build":{"artifact":"hmpps-complexity-of-need","version":"af79nbc","name":"hmpps-complexity-of-need"},"productId":"PROD1"}')
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1541

CNL was missing this `info` endpoint. We have this same endpoint in MPC. It outputs the same details as it is standard in all HMPPS services.