### PR TITLE
Tidy up circle contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,6 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_staging
           env: staging
-          context:
-            - hmpps-common-vars
-            - hmpps-complexity-of-need-staging
           requires:
             - build_and_push_image
           filters: { branches: { only: [ main, staging ] } }
@@ -91,7 +88,6 @@ workflows:
           name: deploy_preprod
           env: preprod
           context:
-            - hmpps-common-vars
             - hmpps-complexity-of-need-preprod
           requires:
             - build_and_push_image

--- a/helm_deploy/README.md
+++ b/helm_deploy/README.md
@@ -2,42 +2,49 @@
 
 ## Configure ENV variables in CircleCI
 
-In order to perform deploys through CircleCI, the following ENV variables must be configured:
+In order to perform deploys through CircleCI, the following ENV variables must be configured.  
+Usually you don't have to add them manually as there are [scripts](https://github.com/ministryofjustice/hmpps-project-bootstrap?tab=readme-ov-file#what-it-does) to do so.
+
+This serves as a reference to have a general knowledge of what is needed in CircleCI for deploys to work.
 
 __Common variables__
 
 These are added in [Project Settings > Environment Variables](https://app.circleci.com/settings/project/github/ministryofjustice/hmpps-complexity-of-need/environment-variables)
-and are common to any deploy environment (staging, preprod, production...)
+and are common to any deploy environment (staging, preprod, production...). Also contains the KUBE variables of, usually,
+staging (or dev) environment. This will normally be the first namespace that was created.
 
 1. `KUBE_ENV_API` with value `https://DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`
 2. `KUBE_ENV_NAME` with value `DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`
-3. `QUAYIO_USERNAME` (ask a team colleague if you don't have it)
-4. `QUAYIO_PASSWORD` (ask a team colleague if you don't have it)
+3. `QUAYIO_USERNAME`
+4. `QUAYIO_PASSWORD`
+5. `KUBE_ENV_NAMESPACE` (read below, this usually will be staging one)
+6. `KUBE_ENV_TOKEN` (read below, this usually will be staging one)
+7. `KUBE_ENV_CACERT` (read below, this usually will be staging one)
 
 __Namespace-dependent variables__
 
-A context needs to be created for each of the deployment envs (so one for staging, another for preprod, etc.)
+A context needs to be created for each additional deployment envs (so one for preprod, another for production, etc.)
 
 1. Go to [Contexts for the Ministry of Justice's CircleCI organisation](https://app.circleci.com/settings/organization/github/ministryofjustice/contexts).
 2. Click on "Create Context" button.
-3. Name the context using the name of this project and the name of the environment: `hmpps-complexity-of-need-<environment>` e.g. `hmpps-complexity-of-need-staging`.
+3. Name the context using the name of this project and the name of the environment: `hmpps-complexity-of-need-<environment>` e.g. `hmpps-complexity-of-need-preprod`.
 4. Click on "Add Environment Variable" button.
-5. Add an environment variable called `KUBE_ENV_NAMESPACE` and set the value to the Kubernetes namespace for the environment e.g. `hmpps-complexity-of-need-staging`.
+5. Add an environment variable called `KUBE_ENV_NAMESPACE` and set the value to the Kubernetes namespace for the environment e.g. `hmpps-complexity-of-need-preprod`.
 6. Using the command line, list the name of all the secrets within the Kubernetes namespace for the environment.
     ```bash
     kubectl get secrets -n <namespace>
-    # E.g. kubectl get secrets -n hmpps-complexity-of-need-staging
+    # E.g. kubectl get secrets -n hmpps-complexity-of-need-preprod
     ```
 7. Using the name of the CircleCI service account secret, retrieve the token for it.
     ```bash
     cloud-platform decode-secret -s <circleci-token-secret-name> -n <namespace> | jq -r '.data."token"'
-    # E.g. cloud-platform decode-secret -s circleci-token-z123 -n hmpps-complexity-of-need-staging | jq -r '.data."token"'
+    # E.g. cloud-platform decode-secret -s circleci-token-z123 -n hmpps-complexity-of-need-preprod | jq -r '.data."token"'
     ```
 8. Add an environment variable called `KUBE_ENV_TOKEN` and set the value to the response of the previous command.
 9. Using the command-line, retrieve the CA certificate for the CircleCI service account.
     ```bash
     kubectl get secrets <circleci-token-secret-name> -n <namespace> -o json | jq -r '.data."ca.crt"'
-    # E.g. kubectl get secrets circleci-token-z123 -n hmpps-complexity-of-need-staging -o json | jq -r '.data."ca.crt"'
+    # E.g. kubectl get secrets circleci-token-z123 -n hmpps-complexity-of-need-preprod -o json | jq -r '.data."ca.crt"'
     ```
 10. Add an environment variable called `KUBE_ENV_CACERT` and set the value to the response of the previous command.
 11. Repeat these steps for all of the environments required (preprod, production...), adding a new context for each one with their corresponding environment variables.
@@ -56,7 +63,7 @@ __Test chart template rendering:__
 This will out the fully rendered kubernetes resources in raw yaml.
 
 ```sh
-helm template [path to chart] --values=path/to/values-dev.yaml
+helm template [path to chart] --values=path/to/values-staging.yaml
 ```
 
 __List releases:__


### PR DESCRIPTION
We are removing `hmpps-complexity-of-need-staging` context and integrating their variables into the project settings ENV variables.

Additionally, `hmpps-common-vars` context is only needed in the deploy to production, so removed references where unneeded.