### PR TITLE
Add back /ping endpoint for backwards compat

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "/swagger-ui.html", to: redirect("/api-docs/index.html", status: 302)
   get "/v3/api-docs", to: "swagger_docs#index"
 
+  get "/ping" => "health#ping"
   get "/health/ping" => "health#ping"
   get "/health" => "health#index"
   get "/info" => "info#index"

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe "Health", type: :request do
   let(:build_number) { "2014-12-25.52422.e70d4e2" }
   let(:git_ref) { "e70d4e2" }
 
+  describe "GET /ping" do
+    it "says pong" do
+      get "/ping"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq("pong")
+    end
+  end
+
   describe "GET /health/ping" do
     it "says pong" do
       get "/health/ping"


### PR DESCRIPTION
Some services from other teams were using the old /ping endpoint. Keep both for the time being (/ping and /health/ping) to not cause false positives in their health checks.