### PR TITLE
MO-1591 Add updated_at timestamp to JSON response

### DIFF
--- a/Complexity Of Need API Specification.yaml
+++ b/Complexity Of Need API Specification.yaml
@@ -109,6 +109,11 @@ components:
           format: date_time
           description: The date & time this entry was created (in RFC 3339 format)
           example: '2021-03-02T17:18:46.457Z'
+        updatedTimeStamp:
+          type: string
+          format: date_time
+          description: The date & time this entry was updated (in RFC 3339 format)
+          example: '2021-03-02T17:18:46.457Z'
         active:
           type: boolean
           description: Whether it is active or not
@@ -116,6 +121,7 @@ components:
       - offenderNo
       - level
       - createdTimeStamp
+      - updatedTimeStamp
       - sourceSystem
       additionalProperties: false
     NewComplexityOfNeed:

--- a/app/views/shared/_complexity.json.jbuilder
+++ b/app/views/shared/_complexity.json.jbuilder
@@ -3,6 +3,7 @@
 json.offenderNo complexity.offender_no
 json.extract! complexity, :level
 json.createdTimeStamp complexity.created_at
+json.updatedTimeStamp complexity.updated_at
 json.sourceUser complexity.source_user if complexity.source_user
 json.sourceSystem complexity.source_system
 json.extract! complexity, :notes if complexity.notes

--- a/spec/requests/v1/complexities_request_spec.rb
+++ b/spec/requests/v1/complexities_request_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Complexities", type: :request do
                              level: complexity.level,
                              sourceSystem: complexity.source_system,
                              createdTimeStamp: complexity.created_at,
+                             updatedTimeStamp: complexity.updated_at,
                              active: complexity.active)
       end
     end
@@ -49,6 +50,7 @@ RSpec.describe "Complexities", type: :request do
                              level: complexity.level,
                              sourceSystem: complexity.source_system,
                              createdTimeStamp: complexity.created_at,
+                             updatedTimeStamp: complexity.updated_at,
                              active: complexity.active)
       end
     end
@@ -90,6 +92,7 @@ RSpec.describe "Complexities", type: :request do
             .to eq json_object(level: most_recent.level,
                                offenderNo: offender_no,
                                createdTimeStamp: most_recent.created_at,
+                               updatedTimeStamp: most_recent.updated_at,
                                sourceSystem: most_recent.source_system,
                                active: most_recent.active)
       end
@@ -161,6 +164,7 @@ RSpec.describe "Complexities", type: :request do
                              level: post_body.fetch(:level),
                              sourceSystem: source_system,
                              createdTimeStamp: complexity.created_at,
+                             updatedTimeStamp: complexity.updated_at,
                              active: complexity.active)
       end
     end
@@ -188,6 +192,7 @@ RSpec.describe "Complexities", type: :request do
                              level: post_body.fetch(:level),
                              sourceSystem: source_system,
                              createdTimeStamp: complexity.created_at,
+                             updatedTimeStamp: complexity.updated_at,
                              active: complexity.active)
       end
     end
@@ -317,6 +322,7 @@ RSpec.describe "Complexities", type: :request do
             sourceUser: most_recent.source_user,
             notes: most_recent.notes,
             createdTimeStamp: most_recent.created_at,
+            updatedTimeStamp: most_recent.updated_at,
             active: most_recent.active,
           }.compact # Remove nil values – sourceUser and notes are optional
         end
@@ -353,6 +359,7 @@ RSpec.describe "Complexities", type: :request do
             level: most_recent.level,
             sourceSystem: most_recent.source_system,
             createdTimeStamp: most_recent.created_at,
+            updatedTimeStamp: most_recent.updated_at,
             active: most_recent.active,
           }
         end
@@ -436,6 +443,7 @@ RSpec.describe "Complexities", type: :request do
         expect(response_json.first).to eq json_object(level: complexity.level,
                                                       offenderNo: complexity.offender_no,
                                                       createdTimeStamp: complexity.created_at,
+                                                      updatedTimeStamp: complexity.updated_at,
                                                       sourceSystem: complexity.source_system,
                                                       active: complexity.active)
       end
@@ -466,6 +474,7 @@ RSpec.describe "Complexities", type: :request do
           expect(json).to eq json_object(level: history[index].level,
                                          offenderNo: history[index].offender_no,
                                          createdTimeStamp: history[index].created_at,
+                                         updatedTimeStamp: history[index].updated_at,
                                          sourceSystem: history[index].source_system,
                                          active: history[index].active)
         end
@@ -479,6 +488,7 @@ RSpec.describe "Complexities", type: :request do
             expect(json).to eq json_object(level: history[index].level,
                                            offenderNo: history[index].offender_no,
                                            createdTimeStamp: history[index].created_at,
+                                           updatedTimeStamp: history[index].updated_at,
                                            sourceSystem: history[index].source_system,
                                            active: history[index].active)
           end
@@ -547,6 +557,7 @@ RSpec.describe "Complexities", type: :request do
                              level: complexity.level,
                              sourceSystem: complexity.source_system,
                              createdTimeStamp: complexity.created_at,
+                             updatedTimeStamp: complexity.updated_at,
                              active: complexity.active)
         expect(complexity.active).to be(false)
       end

--- a/spec/requests/v1/subject_access_request_spec.rb
+++ b/spec/requests/v1/subject_access_request_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe "Subject access request", type: :request do
               sourceUser: c.source_user,
               notes: c.notes,
               createdTimeStamp: c.created_at,
+              updatedTimeStamp: c.updated_at,
               active: c.active,
             }
           end,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -103,12 +103,18 @@ RSpec.configure do |config|
                 description: "The date & time this entry was created (in RFC 3339 format)",
                 example: "2021-03-02T17:18:46.457Z",
               },
+              updatedTimeStamp: {
+                type: :string,
+                format: :date_time,
+                description: "The date & time this entry was updated (in RFC 3339 format)",
+                example: "2021-03-02T17:18:46.457Z",
+              },
               active: {
                 type: :boolean,
                 description: "Whether it is active or not",
               },
             },
-            required: %w[offenderNo level createdTimeStamp sourceSystem active],
+            required: %w[offenderNo level createdTimeStamp updatedTimeStamp sourceSystem active],
             additionalProperties: false,
           },
           NewComplexityOfNeed: {

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -83,6 +83,12 @@
             "description": "The date & time this entry was created (in RFC 3339 format)",
             "example": "2021-03-02T17:18:46.457Z"
           },
+          "updatedTimeStamp": {
+            "type": "string",
+            "format": "date_time",
+            "description": "The date & time this entry was updated (in RFC 3339 format)",
+            "example": "2021-03-02T17:18:46.457Z"
+          },
           "active": {
             "type": "boolean",
             "description": "Whether it is active or not"
@@ -92,6 +98,7 @@
           "offenderNo",
           "level",
           "createdTimeStamp",
+          "updatedTimeStamp",
           "sourceSystem",
           "active"
         ],


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1591

This is useful for the SAR team and we usually include the `updated_at` attribute in all our other API responses but for some reason we missed it here.

Some more background in the slack convo:
https://mojdt.slack.com/archives/C01SNQDC10R/p1732892825071899