### PR TITLE
Stop reporting to sentry appinsights exceptions

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,4 +7,8 @@ Sentry.init do |config|
 
   config.breadcrumbs_logger = [:active_support_logger]
   config.release = ENV["BUILD_NUMBER"]
+
+  config.before_send = lambda do |event, hint|
+    hint[:exception].full_message.match?(/ApplicationInsights::TelemetryClient/) ? nil : event
+  end
 end


### PR DESCRIPTION
Some exceptions make our application insights integration (a gem that is really old as there is no viable alternative) blow up with the following message:

```
NoMethodError: undefined method '[]' for nil (NoMethodError)

            :file_name => match['file'],
                               ^^^^^^^^
  from application_insights/telemetry_client.rb:86:in `block in ApplicationInsights::TelemetryClient#track_exception'
  [...]
```

This exception is then reported to Sentry, sometimes in big quantities, risking depleting our quota. As we can't really do anything about it at this time, at least we can skip these unhelpful errors from being reported to Sentry.