### PR TITLE
Add missing need requirement in deploy_prod

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -121,6 +121,7 @@ jobs:
   deploy_production:
     name: Deploy to production
     needs:
+      - build
       - deploy_preprod
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit


### PR DESCRIPTION
It is used to obtain the `app_version`:

```
app_version: '${{ needs.build.outputs.app_version }}'
```