### PR TITLE
MO-1800 Ensure 204 response when no results

### DIFF
--- a/app/controllers/subject_access_request_controller.rb
+++ b/app/controllers/subject_access_request_controller.rb
@@ -11,12 +11,13 @@ class SubjectAccessRequestController < ApplicationController
     return render_error("CRN parameter not allowed", 3, 209) if params[:crn].present?
     return render_error("Invalid date format", 4, 210) unless parse_dates
 
-    @complexities = Complexity.where(offender_no: params[:prn]).order(created_at: :asc)
-    return not_found if @complexities.none?
+    query = Complexity.where(offender_no: params[:prn])
+    query = query.where(created_at: @from_date.beginning_of_day..@to_date.end_of_day) if @from_date && @to_date
 
-    if @from_date && @to_date
-      @complexities = @complexities.where("DATE(created_at) BETWEEN ? AND ?", @from_date, @to_date)
-    end
+    @complexities = query.order(:created_at)
+    return not_found if @complexities.blank?
+
+    @complexities
   end
 
 private

--- a/spec/requests/v1/subject_access_request_spec.rb
+++ b/spec/requests/v1/subject_access_request_spec.rb
@@ -92,11 +92,31 @@ RSpec.describe "Subject access request", type: :request do
       it_behaves_like "returns an error response"
     end
 
-    context "with no matching complexities" do
+    context "with no dates and no matching complexities" do
       include_context "with mocked token"
 
       let(:get_body) do
         { prn: "bobbins" }
+      end
+
+      it "returns 204" do
+        expect(response).to have_http_status :no_content
+      end
+
+      it "returns blank body" do
+        expect(response.body).to eq ""
+      end
+    end
+
+    context "with dates and no matching complexities" do
+      include_context "with mocked token"
+
+      let(:get_body) do
+        {
+          prn: "bobbins",
+          fromDate: time1.to_date.to_s,
+          toDate: time2.to_date.to_s,
+        }
       end
 
       it "returns 204" do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1800

There was a scenario when 200 instead of 204 was returned for an empty result set.

Improved the logic to ensure 204 is returned as per SAR spec.