### PR TITLE
MO-1968 Migrate SAR template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,6 @@
 
 ## Auth and request handling
 - Auth is custom JWT handling, not Devise/OAuth middleware. `ApplicationController` parses the bearer token into `HmppsApi::Oauth::Token`, validates signature against cached JWKS from HMPPS Auth, and checks roles manually (`app/controllers/application_controller.rb`, `app/services/hmpps_api/oauth/token.rb`).
-- `ROLE_CNL_ADMIN` bypasses endpoint-specific role checks; preserve that override when changing authorisation.
 - `create` permits camelCase `sourceUser` but persists it as `source_user`, and always sets `source_system` from `token.client_id`, not the request body (`ComplexitiesController#create`).
 
 ## Developer workflows

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ API Specification [![API docs](https://img.shields.io/badge/API_docs-view-85EA2D
 
 Posted event Specification [![Event docs](https://img.shields.io/badge/Event_docs-view-85EA2D.svg)](https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/ministryofjustice/hmpps-complexity-of-need/main/Complexity%20of%20Need%20Event%20Specification.yaml)
 
+## Roles
+
+This service expects HMPPS Auth bearer tokens and checks roles in the application.
+
+- `ROLE_COMPLEXITY_OF_NEED` for read endpoints under `/v1/complexity-of-need`
+- `ROLE_UPDATE_COMPLEXITY_OF_NEED` for write endpoints under `/v1/complexity-of-need`
+- `ROLE_SAR_DATA_ACCESS` for `/subject-access-request` and `/subject-access-request/template`
+
 The *tests* job in `.github/workflows/pipeline.yml` will mock calls to HMPPS auth.  
 Running tests locally will perform these calls to the real auth service. You can also run the tests locally 
 with mocked calls: `MOCK_AUTH=1 bundle exec rspec`  

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::API
   READ_ROLE = "ROLE_COMPLEXITY_OF_NEED"
   WRITE_ROLE = "ROLE_UPDATE_COMPLEXITY_OF_NEED"
   SAR_ROLE = "ROLE_SAR_DATA_ACCESS"
-  ADMIN_ROLE = "ROLE_CNL_ADMIN"
 
   rescue_from JWT::DecodeError, with: :render_bad_token
 
@@ -26,7 +25,7 @@ private
   def authorise_for!(role)
     if token.nil?
       render_bad_token
-    elsif !token.has_role?(role) && !token.has_role?(ADMIN_ROLE)
+    elsif !token.has_role?(role)
       render_forbidden "You need the role '#{role}' to use this endpoint"
     end
   end

--- a/app/controllers/subject_access_request_controller.rb
+++ b/app/controllers/subject_access_request_controller.rb
@@ -20,6 +20,10 @@ class SubjectAccessRequestController < ApplicationController
     @complexities
   end
 
+  def template
+    render plain: SubjectAccessRequestTemplateService.content, content_type: "text/plain"
+  end
+
 private
 
   def parse_dates

--- a/app/services/subject_access_request_template_service.rb
+++ b/app/services/subject_access_request_template_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SubjectAccessRequestTemplateService
+  TEMPLATE_PATH = Rails.root.join("config/templates/sar_template.mustache").freeze
+
+  class ConfigurationError < StandardError; end
+
+  class << self
+    def template_path
+      TEMPLATE_PATH
+    end
+
+    def content
+      File.read(template_path, encoding: "UTF-8")
+    end
+
+    def validate_configuration!
+      unless template_path.file?
+        raise ConfigurationError, "Invalid subject access request configuration. File '#{template_path}' not found"
+      end
+    end
+  end
+end

--- a/config/initializers/sar_template.rb
+++ b/config/initializers/sar_template.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  SubjectAccessRequestTemplateService.validate_configuration!
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,4 +28,6 @@ Rails.application.routes.draw do
 
     get "/subject-access-request" => "subject_access_request#show"
   end
+
+  get "/subject-access-request/template" => "subject_access_request#template"
 end

--- a/config/templates/sar_template.mustache
+++ b/config/templates/sar_template.mustache
@@ -1,0 +1,14 @@
+<h1 class="title">Complexity of need</h1>
+{{#.}}
+    <h2>Complexity</h2>
+    <table class="summary-list">
+        <tr><td>Level</td><td>{{ optionalValue level }}</td></tr>
+        <tr><td>Active</td><td>{{ convertBoolean active }}</td></tr>
+        <tr><td>Creation</td><td>{{ optionalValue (formatDate createdTimeStamp) }}</td></tr>
+        <tr><td>Updated</td><td>{{ optionalValue (formatDate updatedTimeStamp) }}</td></tr>
+        <tr><td>Notes</td><td>{{ optionalValue notes }}</td></tr>
+    </table>
+{{/.}}
+{{^.}}
+    <p>No Data Held</p>
+{{/.}}

--- a/spec/api/v1/rswag_spec.rb
+++ b/spec/api/v1/rswag_spec.rb
@@ -66,7 +66,7 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.json" do
       parameter name: :body, in: :body, schema: { "$ref" => "#/components/schemas/NewComplexityOfNeed" }
 
       before do
-        stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+        stub_access_token roles: %w[ROLE_UPDATE_COMPLEXITY_OF_NEED]
       end
 
       response "200", "Complexity of Need level set successfully" do
@@ -203,7 +203,7 @@ describe "Complexity of Need API", swagger_doc: "v1/swagger.json" do
     let(:offender_no) { "G4273GI" }
 
     before do
-      stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+      stub_access_token roles: %w[ROLE_UPDATE_COMPLEXITY_OF_NEED]
     end
 
     put "Inactivate the Complexity of Need level for an offender" do

--- a/spec/api/v1/sar_template_spec.rb
+++ b/spec/api/v1/sar_template_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+# rubocop:disable RSpec/VariableName
+# rubocop:disable RSpec/ScatteredSetup
+
+require "swagger_helper"
+
+describe "Complexity of Need API", swagger_doc: "v1/swagger.json" do
+  let(:template_path) { SubjectAccessRequestTemplateService.template_path }
+
+  path "/subject-access-request/template" do
+    get "Retrieves the SAR mustache template for this service" do
+      security [{ Bearer: [] }]
+
+      tags "Subject Access Request"
+      description "* The role ROLE_SAR_DATA_ACCESS is required\n* Returns the plain-text mustache template configured for the service"
+
+      produces "text/plain"
+
+      response "401", "Request is not authorised" do
+        example "application/json", :error_example, {
+          developerMessage: "Missing or invalid access token",
+          errorCode: 1,
+          status: 401,
+          userMessage: "Missing or invalid access token",
+        }
+
+        let(:Authorization) { nil }
+
+        run_test!
+      end
+
+      response "403", "Invalid token role" do
+        example "application/json", :error_example, {
+          developerMessage: "You need the role 'ROLE_SAR_DATA_ACCESS' to use this endpoint",
+          errorCode: 5,
+          status: 403,
+          userMessage: "You need the role 'ROLE_SAR_DATA_ACCESS' to use this endpoint",
+        }
+
+        let(:Authorization) { auth_header }
+
+        before do
+          stub_access_token roles: %w[ROLE_WHATEVER]
+        end
+
+        run_test!
+      end
+
+      response "200", "Template returned" do
+        schema type: :string
+
+        let(:Authorization) { auth_header }
+
+        before do
+          stub_access_token roles: %w[ROLE_SAR_DATA_ACCESS]
+        end
+
+        run_test! do |response|
+          expect(response.media_type).to eq("text/plain")
+          expect(response.body).to eq(File.read(template_path, encoding: "UTF-8"))
+        end
+      end
+    end
+  end
+end
+
+# rubocop:enable RSpec/ScatteredSetup
+# rubocop:enable RSpec/VariableName
+# rubocop:enable RSpec/DescribeClass

--- a/spec/requests/v1/complexities_request_spec.rb
+++ b/spec/requests/v1/complexities_request_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Complexities", type: :request do
     let(:source_system) { Rails.configuration.nomis_oauth_client_id }
 
     before do
-      stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+      stub_access_token roles: %w[ROLE_UPDATE_COMPLEXITY_OF_NEED]
     end
 
     context "with only mandatory fields" do
@@ -538,7 +538,7 @@ RSpec.describe "Complexities", type: :request do
     let!(:complexity) { create(:complexity) }
 
     before do
-      stub_access_token roles: %w[ROLE_CNL_ADMIN ROLE_UPDATE_COMPLEXITY_OF_NEED]
+      stub_access_token roles: %w[ROLE_UPDATE_COMPLEXITY_OF_NEED]
     end
 
     context "when authenticated with correct role" do

--- a/spec/requests/v1/subject_access_request_spec.rb
+++ b/spec/requests/v1/subject_access_request_spec.rb
@@ -168,17 +168,6 @@ RSpec.describe "Subject access request", type: :request do
       end
 
       include_examples "SAR HTTP 403 Forbidden", "You need the role 'ROLE_SAR_DATA_ACCESS' to use this endpoint"
-
-      context "with the role ROLE_CNL_ADMIN" do
-        before do
-          stub_access_token roles: %w[ROLE_CNL_ADMIN]
-          get endpoint, headers: request_headers, params: { prn: offender_no }
-        end
-
-        it "returns status OK" do
-          expect(response).to have_http_status :ok
-        end
-      end
     end
 
     context "when the client is unauthenticated" do

--- a/spec/requests/v1/subject_access_request_template_spec.rb
+++ b/spec/requests/v1/subject_access_request_template_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "shared_examples"
+
+RSpec.describe "Subject access request template", type: :request do
+  let(:endpoint) { "/subject-access-request/template" }
+  let(:response_json) { JSON.parse(response.body) }
+  let(:request_headers) { { "Authorization" => auth_header } }
+  let(:template_path) { SubjectAccessRequestTemplateService.template_path }
+
+  describe "GET /subject-access-request/template" do
+    context "when the client has the ROLE_SAR_DATA_ACCESS role" do
+      before do
+        stub_access_token roles: %w[ROLE_SAR_DATA_ACCESS]
+        get endpoint, headers: request_headers
+      end
+
+      it "returns status OK" do
+        expect(response).to have_http_status :ok
+      end
+
+      it "returns the template body as plain text" do
+        expect(response.media_type).to eq "text/plain"
+        expect(response.body).to eq File.read(template_path, encoding: "UTF-8")
+      end
+    end
+
+    context "when the client lacks the ROLE_SAR_DATA_ACCESS role" do
+      before do
+        stub_access_token roles: %w[ROLE_WHATEVER]
+        get endpoint, headers: request_headers
+      end
+
+      include_examples "SAR HTTP 403 Forbidden", "You need the role 'ROLE_SAR_DATA_ACCESS' to use this endpoint"
+    end
+
+    context "when the client is unauthenticated" do
+      before do
+        get endpoint
+      end
+
+      include_examples "SAR HTTP 401 Unauthorized"
+    end
+  end
+end

--- a/spec/services/subject_access_request_template_service_spec.rb
+++ b/spec/services/subject_access_request_template_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubjectAccessRequestTemplateService do
+  let(:template_path) { described_class.template_path }
+
+  describe "DB schema change guard" do
+    # Keep this updated once any potential SAR drifting is asserted
+    let(:reviewed_version) { "20220725_144655" }
+
+    let(:current_version) { ActiveRecord::Base.connection_pool.migration_context.current_version }
+    let(:message) do
+      <<~MESSAGE
+        A new migration has been added.
+
+        Please review whether the SAR payload or template should change before updating this guard version.
+        Check:
+        - app/views/subject_access_request/show.json.jbuilder
+        - config/templates/sar_template.mustache
+        - spec/api/v1/sar_spec.rb
+        - spec/api/v1/sar_template_spec.rb
+      MESSAGE
+    end
+
+    it "requires a SAR template and payload review when the DB schema changes" do
+      expect(current_version).to eq(reviewed_version.to_i), message
+    end
+  end
+
+  describe ".validate_configuration!" do
+    subject(:validate_configuration!) { described_class.validate_configuration! }
+
+    it "does not raise when the template exists" do
+      expect { validate_configuration! }.not_to raise_error
+    end
+
+    context "when the template path does not exist" do
+      before do
+        allow(described_class).to receive(:template_path).and_return(Pathname.new("/tmp/missing-sar.mustache"))
+      end
+
+      it "raises a configuration error" do
+        expect { validate_configuration! }
+          .to raise_error(described_class::ConfigurationError, /missing-sar.mustache/)
+      end
+    end
+  end
+
+  describe ".content" do
+    subject(:content) { described_class.content }
+
+    let(:expected_content) { File.read(template_path, encoding: "UTF-8") }
+
+    it "returns the template body" do
+      expect(content).to eq(expected_content)
+    end
+  end
+end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -256,9 +256,7 @@
           "Single Offender"
         ],
         "description": "Clients calling this endpoint must have role: `ROLE_UPDATE_COMPLEXITY_OF_NEED`",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Complexity of Need level set successfully",
@@ -298,9 +296,7 @@
           "Multiple Offenders"
         ],
         "description": "This endpoint returns a JSON array containing the current Complexity of Need entry for multiple offenders.\n\nThe response array:\n  - will exclude offenders whose Complexity of Need level is not known (i.e. these would result in a `404 Not Found` error on the single `GET` endpoint)\n  - will exclude offenders without a current active level\n  - is not sorted in the same order as the request body\n  - is not paginated\n",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "OK",
@@ -434,9 +430,7 @@
         "summary": "Retrieves all held info for offender",
         "security": [
           {
-            "Bearer": [
-
-            ]
+            "Bearer": []
           }
         ],
         "tags": [
@@ -587,6 +581,66 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SarOffenderData"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subject-access-request/template": {
+      "get": {
+        "summary": "Retrieves the SAR mustache template for this service",
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "Subject Access Request"
+        ],
+        "description": "* The role ROLE_SAR_DATA_ACCESS is required\n* Returns the plain-text mustache template configured for the service",
+        "responses": {
+          "401": {
+            "description": "Request is not authorised",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "error_example": {
+                    "value": {
+                      "developerMessage": "Missing or invalid access token",
+                      "errorCode": 1,
+                      "status": 401,
+                      "userMessage": "Missing or invalid access token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Invalid token role",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "error_example": {
+                    "value": {
+                      "developerMessage": "You need the role 'ROLE_SAR_DATA_ACCESS' to use this endpoint",
+                      "errorCode": 5,
+                      "status": 403,
+                      "userMessage": "You need the role 'ROLE_SAR_DATA_ACCESS' to use this endpoint"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Template returned",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1968
Parent: https://dsdmoj.atlassian.net/browse/MO-1960

Move existing SAR template from the `hmpps-subject-access-request-html-renderer` repo to be served by our own service.

The template has been copy&pasted "as-is" with no changes at all, and is served as text/plain.

Removed invalid and nonexistent `ROLE_CNL_ADMIN` code.