### PR TITLE
Disable app insights track_exception

### DIFF
--- a/app/controllers/subject_access_request_controller.rb
+++ b/app/controllers/subject_access_request_controller.rb
@@ -53,6 +53,8 @@ private
   end
 
   def render_error(msg, error_code, status)
+    Rails.logger.warn("event=subject_access_request_error|status=#{status}|error_code=#{error_code}|message=#{msg}")
+
     render json: {
       developerMessage: msg,
       errorCode: error_code,

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module HmppsComplexityOfNeed
 
     config.action_dispatch.default_headers["X-Robots-Tag"] = "noindex, nofollow"
 
+    # Sentry environment set with SENTRY_CURRENT_ENV
+    config.sentry_dsn = ENV["SENTRY_DSN"]&.strip
+
     # Always required
     config.nomis_oauth_host = ENV.fetch("NOMIS_OAUTH_HOST")&.strip
 

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -8,6 +8,11 @@ Rails.application.configure do
     require "patches/application_insights/telemetry_context"
     ApplicationInsights::Channel::TelemetryContext.prepend Patches::ApplicationInsights::TelemetryContext
 
+    # Disable Application Insights exception reporting and rely on Sentry instead,
+    # because the upstream gem's parser is not compatible with our Ruby/Rails versions.
+    require "patches/application_insights/telemetry_client"
+    ApplicationInsights::TelemetryClient.prepend Patches::ApplicationInsights::TelemetryClient
+
     config.middleware.use(
       ApplicationInsights::Rack::TrackRequest, key
     )

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -8,10 +8,6 @@ Rails.application.config.filter_parameters += %i[
   secret
   token
   _key
-  crypt
-  salt
-  certificate
-  otp
-  ssn
   _json
+  notes
 ]

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,15 +1,60 @@
 # frozen_string_literal: true
 
-Sentry.init do |config|
-  # 'DSN' and 'environment' are automatically pulled in from
-  # environment variables SENTRY_DSN and SENTRY_CURRENT_ENV
-  # so no need to configure them here
+sentry_dsn = Rails.configuration.sentry_dsn
 
-  config.breadcrumbs_logger = [:active_support_logger]
-  config.release = ENV["BUILD_NUMBER"]
-  config.enable_metrics = false
+if sentry_dsn.present?
+  require "active_support/parameter_filter"
+  param_filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
 
-  config.before_send = lambda do |event, hint|
-    hint[:exception].full_message.match?(/ApplicationInsights::TelemetryClient/) ? nil : event
+  Sentry.init do |config|
+    config.dsn = sentry_dsn
+    config.release = ENV["BUILD_NUMBER"]
+    config.enable_metrics = false
+    config.rails.report_rescued_exceptions = false
+
+    if Rails.env.development?
+      config.background_worker_threads = 0
+      config.sdk_logger = Sentry::Logger.new($stdout).tap { it.level = Logger::DEBUG }
+    end
+
+    config.excluded_exceptions += %w[
+      JWT::ExpiredSignature
+      JWT::VerificationError
+      ActiveRecord::RecordNotFound
+      ActionController::RoutingError
+      ActionController::UnknownFormat
+      ActionController::InvalidAuthenticityToken
+      ActionController::BadRequest
+      Faraday::ConnectionFailed
+      Faraday::TimeoutError
+    ]
+
+    config.before_send = lambda do |event, hint|
+      begin
+        # Sanitize extra data
+        if event.extra
+          event.extra = param_filter.filter(event.extra)
+        end
+
+        # Sanitize user data
+        if event.user
+          event.user = param_filter.filter(event.user)
+        end
+
+        # Sanitize context data
+        if event.contexts
+          event.contexts = param_filter.filter(event.contexts)
+        end
+      rescue StandardError => e
+        Rails.logger.warn(
+          "event=sentry_sanitization_error|original_exception_class=#{hint[:exception]&.class}|#{e.message}",
+        )
+      end
+
+      # Return the sanitized event object
+      event
+    end
   end
+else
+  Rails.logger.warn "[WARN] Sentry is not configured (SENTRY_DSN)"
 end

--- a/lib/patches/application_insights/telemetry_client.rb
+++ b/lib/patches/application_insights/telemetry_client.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Patches
+  module ApplicationInsights
+    module TelemetryClient
+      def track_exception(_exception, _options = {})
+        nil
+      end
+    end
+  end
+end

--- a/spec/initializers/sentry_initializer_spec.rb
+++ b/spec/initializers/sentry_initializer_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Sentry do
+  let(:sentry_dsn) { "https://examplePublicKey@o0.ingest.sentry.io/0" }
+  let(:rails_config) { instance_double(Sentry::Rails::Configuration) }
+  let(:config_class) do
+    Struct.new(:dsn, :release, :enable_metrics, :excluded_exceptions, :before_send, :rails, keyword_init: true)
+  end
+  let(:config) { config_class.new(excluded_exceptions: [], rails: rails_config) }
+
+  before do
+    allow(rails_config).to receive(:report_rescued_exceptions=)
+    allow(Rails.configuration).to receive(:sentry_dsn).and_return(sentry_dsn)
+    allow(described_class).to receive(:init).and_yield(config)
+  end
+
+  it "configures the essential Sentry settings" do
+    load Rails.root.join("config/initializers/sentry.rb")
+
+    expect(config).to have_attributes(
+      dsn: sentry_dsn,
+      release: ENV["BUILD_NUMBER"],
+      enable_metrics: false,
+    )
+  end
+
+  it "disables reporting rescued exceptions via the Rails integration" do
+    load Rails.root.join("config/initializers/sentry.rb")
+
+    expect(rails_config).to have_received(:report_rescued_exceptions=).with(false)
+  end
+
+  it "configures the expected excluded exceptions" do
+    load Rails.root.join("config/initializers/sentry.rb")
+
+    expect(config.excluded_exceptions).to include("JWT::ExpiredSignature", "Faraday::TimeoutError")
+  end
+
+  context "when the Sentry DSN is blank" do
+    let(:sentry_dsn) { "" }
+
+    it "logs a warning and skips Sentry initialisation" do
+      allow(Rails.logger).to receive(:warn)
+
+      load Rails.root.join("config/initializers/sentry.rb")
+
+      expect(described_class).not_to have_received(:init)
+      expect(Rails.logger).to have_received(:warn)
+    end
+  end
+end

--- a/spec/lib/patches/application_insights/telemetry_client_spec.rb
+++ b/spec/lib/patches/application_insights/telemetry_client_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+require "application_insights"
+require Rails.root.join("lib/patches/application_insights/telemetry_client")
+
+ApplicationInsights::TelemetryClient.prepend(Patches::ApplicationInsights::TelemetryClient) unless
+  ApplicationInsights::TelemetryClient < Patches::ApplicationInsights::TelemetryClient
+
+RSpec.describe ApplicationInsights::TelemetryClient do
+  subject(:client) { described_class.new("test-key", channel) }
+
+  let(:channel) { instance_double(ApplicationInsights::Channel::TelemetryChannel, write: true) }
+
+  describe "#track_exception" do
+    let(:exception) do
+      StandardError.new("boom").tap do |error|
+        error.set_backtrace(["app/views/example.html.erb:1"])
+      end
+    end
+
+    it "does not send exception telemetry to Application Insights" do
+      expect(client.track_exception(exception, handled_at: "Unhandled")).to be_nil
+      expect(channel).not_to have_received(:write)
+    end
+  end
+end

--- a/spec/requests/v1/subject_access_request_spec.rb
+++ b/spec/requests/v1/subject_access_request_spec.rb
@@ -59,8 +59,6 @@ RSpec.describe "Subject access request", type: :request do
     end
 
     context "when passed both a prn and crn as query parameters" do
-      include_context "with mocked token"
-
       let(:get_body) do
         {
           prn: "bobbins",
@@ -68,8 +66,20 @@ RSpec.describe "Subject access request", type: :request do
         }
       end
 
+      before do
+        allow(Rails.logger).to receive(:warn)
+        stub_access_token roles: %w[ROLE_SAR_DATA_ACCESS]
+        get endpoint, headers: request_headers, params: get_body
+      end
+
       it "returns status 400" do
         expect(response).to have_http_status :bad_request
+      end
+
+      it "logs a warning" do
+        expect(Rails.logger).to have_received(:warn).with(
+          "event=subject_access_request_error|status=400|error_code=2|message=Cannot supply both CRN and PRN",
+        )
       end
 
       it_behaves_like "returns an error response"


### PR DESCRIPTION
Mostly backported from the implementation on MPC, because CNL has the same issue with application insights hijacking and messing with sentry exceptions.

https://github.com/ministryofjustice/offender-management-allocation-manager/pull/2816