### PR TITLE
Upgrade docker image alpine packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM ruby:4.0.1-alpine3.23 AS builder
 WORKDIR /app
 
 # Build-only dependencies required for native gems.
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache \
+  && apk add --no-cache \
   build-base \
   postgresql-dev \
-  yaml-dev \
-  && apk upgrade --no-cache zlib
+  yaml-dev
 
 COPY Gemfile* .ruby-version ./
 
@@ -29,11 +29,11 @@ ENV LANG=C.UTF-8 \
 WORKDIR /app
 
 # Runtime libraries only.
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache \
+  && apk add --no-cache \
   ca-certificates \
   tzdata \
-  postgresql-libs \
-  && apk upgrade --no-cache zlib
+  postgresql-libs
 
 RUN addgroup -S appgroup -g 1001 \
   && adduser -S appuser -u 1001 -G appgroup -h /home/appuser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     application_insights (0.5.6)
     ast (2.4.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1250.0)
+    aws-partitions (1.1251.0)
     aws-sdk-core (3.247.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -89,7 +89,7 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-sns (1.114.0)
+    aws-sdk-sns (1.115.0)
       aws-sdk-core (~> 3, >= 3.247.0)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
@@ -125,7 +125,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -167,7 +167,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -184,6 +184,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
@@ -195,6 +197,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
@@ -377,9 +380,10 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
+  aarch64-linux-musl
   arm64-darwin-25
   x86_64-linux
   x86_64-linux-musl

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,6 +5,7 @@ Rails.application.configure do
   # Reduce noise in the logs by ignoring the healthcheck actions
   config.lograge.ignore_actions = %w[
     HealthController#index
+    HealthController#ping
   ]
 
   config.lograge.custom_options = lambda do |event|


### PR DESCRIPTION
Updates the docker build to pull patched alpine packages in both the build and runtime stages, which should address a few Snyk reported vulns.

Also, reduce logging noise by ignoring ping traces.